### PR TITLE
support `textDocument/references`, address parallelism issues with test runner

### DIFF
--- a/src/init_dot_lua.rs
+++ b/src/init_dot_lua.rs
@@ -38,7 +38,11 @@ pub fn get_init_dot_lua(
     );
     // This is how we actually invoke the action to be tested
     match test_type {
-        TestType::Hover | TestType::Completion | TestType::Definition | TestType::Rename => {
+        TestType::Hover
+        | TestType::Completion
+        | TestType::Definition
+        | TestType::References
+        | TestType::Rename => {
             raw_init = raw_init.replace("LSP_ACTION", &invoke_lsp_action(&test_case.start_type));
         }
         TestType::Diagnostic => {
@@ -100,6 +104,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::Diagnostic => "\n-- NOTE: No `check_progress_result` function for diagnostics, instead handled by `DiagnosticChanged` autocmd\n",
         TestType::Completion => include_str!("lua_templates/completion_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),
+        TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
     }
     .to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub fn test_rename(
 }
 
 /// Generates a new random test ID
-fn get_test_id() -> String {
+fn generate_test_id() -> String {
     let range = rand::distr::Uniform::new(0, usize::MAX).unwrap();
     let mut rng = rand::rng();
     range.sample(&mut rng).to_string()
@@ -178,7 +178,7 @@ where
     R: serde::de::DeserializeOwned,
 {
     test_case.validate()?;
-    test_case.test_id = get_test_id();
+    test_case.test_id = generate_test_id();
     // Invariant: `test_case.test_type` should always be set to `Some(_)` in the caller
     let source_path = test_case.create_test(
         test_case.test_type.expect("Test type is `None`"),

--- a/src/lua_templates/completion_action.lua
+++ b/src/lua_templates/completion_action.lua
@@ -36,6 +36,6 @@ local function check_progress_result()
         vim.cmd('qa!')
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid completion result returned (Attempt ' .. vim.inspect(completion_result) .. ')\n')
+        report_log('No valid completion result returned: ' .. vim.inspect(completion_result) .. '\n')
     end
 end

--- a/src/lua_templates/definition_action.lua
+++ b/src/lua_templates/definition_action.lua
@@ -42,7 +42,7 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global, exp-in-action
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid definition result returned (Attempt ' .. vim.inspect(definition_results) .. '\n')
+        report_log('No valid definition result returned: ' .. vim.inspect(definition_results) .. '\n')
     end
     vim.cmd('qa!')
 end

--- a/src/lua_templates/diagnostic_autocmd.lua
+++ b/src/lua_templates/diagnostic_autocmd.lua
@@ -41,8 +41,7 @@ vim.api.nvim_create_autocmd('DiagnosticChanged', {
             ---@diagnostic enable: need-check-nil
         else
             ---@diagnostic disable: undefined-global
-            report_log('No diagnostic result returned (Attempt ' ..
-                tostring(progress_count) .. '):\n ' .. vim.inspect(diagnostics_result) .. '\n\n')
+            report_log('No diagnostic result returned: ' .. vim.inspect(diagnostics_result) .. '\n')
             ---@diagnostic enable: undefined-global
         end
     end,

--- a/src/lua_templates/hover_action.lua
+++ b/src/lua_templates/hover_action.lua
@@ -29,6 +29,6 @@ local function check_progress_result()
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid hover result returned (Attempt ' .. vim.inspect(hover_result) .. ')\n')
+        report_log('No valid hover result returned: ' .. vim.inspect(hover_result) .. '\n')
     end
 end

--- a/src/lua_templates/references_action.lua
+++ b/src/lua_templates/references_action.lua
@@ -35,6 +35,6 @@ local function check_progress_result()
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid reference result returned (Attempt ' .. vim.inspect(reference_result) .. ')\n')
+        report_log('No valid reference result returned: ' .. vim.inspect(reference_result) .. '\n')
     end
 end

--- a/src/lua_templates/references_action.lua
+++ b/src/lua_templates/references_action.lua
@@ -1,0 +1,40 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    report_log('Issuing reference request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local reference_result = vim.lsp.buf_request_sync(0, 'textDocument/references', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        ---@diagnostic disable: undefined-global
+        SET_CURSOR_POSITION,
+        SET_CONTEXT
+        ---@diagnostic enable: undefined-global
+    }, 1000)
+    if reference_result and #reference_result >= 1 and reference_result[1].result and #reference_result[1].result >= 1 then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        local refs = reference_result[1].result
+        for i, ref in ipairs(refs) do
+            local relative_path = extract_relative_path(ref.uri) ---@diagnostic disable-line: undefined-global
+            refs[i].uri = relative_path
+        end
+
+        --- NOTE: Does this ever return more than one result? Just use the first for now
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(reference_result[1].result))
+        results_file:close()
+        vim.cmd('qa!')
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid reference result returned (Attempt ' .. vim.inspect(reference_result) .. ')\n')
+    end
+end

--- a/src/lua_templates/rename_action.lua
+++ b/src/lua_templates/rename_action.lua
@@ -37,6 +37,6 @@ local function check_progress_result()
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid rename result returned (Attempt ' .. vim.inspect(rename_result) .. ')\n')
+        report_log('No valid rename result returned: ' .. vim.inspect(rename_result) .. '\n')
     end
 end

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,10 +5,9 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anstyle::{AnsiColor, Color, Style};
-use lsp_types::WorkspaceEdit;
 pub use lsp_types::{
     CompletionItem, CompletionList, CompletionResponse, Diagnostic, GotoDefinitionResponse, Hover,
-    Position,
+    Location, Position, WorkspaceEdit,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -26,6 +25,8 @@ pub enum TestType {
     Completion,
     /// Test `textDocument/definition` requests
     Definition,
+    /// Test `textDocument/references` requests
+    References,
     /// Test `textDocument/rename` requests
     Rename,
 }
@@ -40,6 +41,7 @@ impl std::fmt::Display for TestType {
                 Self::Definition => "definition",
                 Self::Diagnostic => "publishDiagnostics",
                 Self::Hover => "hover",
+                Self::References => "references",
                 Self::Rename => "rename",
             }
         )?;
@@ -483,6 +485,8 @@ pub enum TestError {
     #[error(transparent)]
     HoverMismatch(#[from] Box<HoverMismatchError>),
     #[error(transparent)]
+    ReferencesMismatch(#[from] ReferencesMismatchError),
+    #[error(transparent)]
     RenameMismatch(#[from] Box<RenameMismatchError>),
     #[error("No results were written")]
     NoResults,
@@ -881,6 +885,21 @@ impl std::fmt::Display for CompletionMismatchError {
             },
         };
 
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub struct ReferencesMismatchError {
+    pub test_id: String,
+    pub expected: Vec<Location>,
+    pub actual: Vec<Location>,
+}
+
+impl std::fmt::Display for ReferencesMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect References response:", self.test_id)?;
+        write_fields_comparison(f, "Location", &self.expected, &self.actual, 0)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Quick two part PR:

1. Support `textDocument/references`
- This was pretty quick and painless.

2. Fix parallelism issues with Cargo's test runner.
- This was pretty interesting. It looks like once there's enough tests to run (relative to the number of cores for the host machine), tests will begin to intermittently fail with timeout failures. An easy solution to this is to limit the number of threads used by the test runner, i.e. `cargo test -- --test-threads 3`. It's not reasonable to expected consumers of the library to restrict their local and testing and CI though! A better solution I found is to treat the "neovim section" of each test as a critical section, restricting the number of tests that can enter at a given time. 