### PR TITLE
feat: `textDocument/formatting` (and other stuff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To start though, let's focus on the following TODOs:
 - [x] `textDocument/references`
 - [ ] `textDocument/definition` (partially addressed)
 - [ ] `textDocument/completion` (partially addressed)
-- [ ] `textDocument/formatting`
+- [x] `textDocument/formatting`
 - [x] `textDocument/rename`
 
 ## Gotchas

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To start though, let's focus on the following TODOs:
 
 - If your server undergoes some sort of indexing process at startup before it's ready
 to service a given request, you need to account for this by specifying `ServerStartType::Progress(i32, String)`
-to the test case. The `i32` specifies *which* `end` message to issue the request
+to the test case. The `NonZeroU32` specifies *which* `end` message to issue the request
 after (in case there are multiple). The `String` provides the relevant [progress token][progress-token].
 
 - **String comparison of results**: Many LSP client implementations do some post processing

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To start though, let's focus on the following TODOs:
 - [ ] `textDocument/definition` (partially addressed)
 - [ ] `textDocument/completion` (partially addressed)
 - [ ] `textDocument/formatting`
-- [ ] `textDocument/rename`
+- [x] `textDocument/rename`
 
 ## Gotchas
 

--- a/src/init_dot_lua.rs
+++ b/src/init_dot_lua.rs
@@ -42,7 +42,8 @@ pub fn get_init_dot_lua(
         | TestType::Completion
         | TestType::Definition
         | TestType::References
-        | TestType::Rename => {
+        | TestType::Rename
+        | TestType::Formatting => {
             raw_init = raw_init.replace("LSP_ACTION", &invoke_lsp_action(&test_case.start_type));
         }
         TestType::Diagnostic => {
@@ -100,10 +101,11 @@ fn progress_threshold(start_type: &ServerStartType) -> String {
 
 fn get_attach_action(test_type: TestType) -> String {
     match test_type {
-        TestType::Hover => include_str!("lua_templates/hover_action.lua"),
-        TestType::Diagnostic => "\n-- NOTE: No `check_progress_result` function for diagnostics, instead handled by `DiagnosticChanged` autocmd\n",
         TestType::Completion => include_str!("lua_templates/completion_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),
+        TestType::Diagnostic => "\n-- NOTE: No `check_progress_result` function for diagnostics, instead handled by `DiagnosticChanged` autocmd\n",
+        TestType::Formatting => include_str!("lua_templates/formatting_action.lua"),
+        TestType::Hover => include_str!("lua_templates/hover_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! lspresso_shot {
 /// each case's "neovim portion" inside `run_test` as a critical section. Another
 /// approach that works is to manually limit the number of threads used by the test
 /// runner via `--test-threads x`, but it isn't realistic to expect consumers to do this.
-static RUNNER_LIMIT: u32 = 3;
+static RUNNER_LIMIT: u32 = 1;
 static RUNNER_COUNT: OnceLock<Arc<(Mutex<u32>, Condvar)>> = OnceLock::new();
 
 fn get_runner_count() -> Arc<(Mutex<u32>, Condvar)> {

--- a/src/lua_templates/formatting_action.lua
+++ b/src/lua_templates/formatting_action.lua
@@ -13,31 +13,48 @@ local function check_progress_result()
     json_opts = [[
 JSON_OPTIONS
     ]]
+    format_opts = vim.json.decode(json_opts) ---@diagnostic disable-line: undefined-global, lowercase-global
 
+    report_log('Format opts: ' .. tostring(vim.inspect(format_opts)) .. '\n') ---@diagnostic disable-line: undefined-global
     report_log('Issuing formatting request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
-    report_log('JSON opts: ' .. json_opts .. '\n') ---@diagnostic disable-line: undefined-global
 
-    local formatting_result = vim.lsp.buf_request_sync(0, 'textDocument/formatting', {
-        textDocument = vim.lsp.util.make_text_document_params(0),
-        -- Decode the `FormattingOptions` into a lua table
-        ---@diagnostic disable: undefined-global
-        options = vim.json.decode(json_opts)
-        ---@diagnostic enable: undefined-global
-    }, 1000)
-    if formatting_result and #formatting_result >= 1 and formatting_result[1].result and #formatting_result[1].result >= 1 then
+    if INVOKE_FORMAT then ---@diagnostic disable-line: undefined-global
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
-        --- NOTE: Does this ever return more than one result? Just use the first for now
+        vim.lsp.buf.format({
+            async = false,
+            formatting_options = format_opts
+        })
+        local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
+        local formatted = table.concat(lines, "\\n")
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(formatting_result[1].result))
+        results_file:write('"' .. formatted .. '"')
         results_file:close()
         vim.cmd('qa!')
         ---@diagnostic enable: need-check-nil
     else
-        ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid formatting result returned: ' .. vim.inspect(formatting_result) .. '\n')
+        local formatting_result = vim.lsp.buf_request_sync(0, 'textDocument/formatting', {
+            textDocument = vim.lsp.util.make_text_document_params(0),
+            options = format_opts
+        }, 1000)
+        if formatting_result and #formatting_result >= 1 and formatting_result[1].result and #formatting_result[1].result >= 1 then
+            local results_file = io.open('RESULTS_FILE', 'w')
+            if not results_file then
+                report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+                vim.cmd('qa!')
+            end
+            --- NOTE: Does this ever return more than one result? Just use the first for now
+            ---@diagnostic disable: need-check-nil
+            results_file:write(vim.json.encode(formatting_result[1].result))
+            results_file:close()
+            vim.cmd('qa!')
+            ---@diagnostic enable: need-check-nil
+        else
+            ---@diagnostic disable-next-line: undefined-global
+            report_log('No valid formatting result returned: ' .. vim.inspect(formatting_result) .. '\n')
+        end
     end
 end

--- a/src/lua_templates/formatting_action.lua
+++ b/src/lua_templates/formatting_action.lua
@@ -1,0 +1,43 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+
+    -- Receive  json-encoded `FormattingOptions` from the rust side in `json_opts`
+    ---@diagnostic disable-next-line: undefined-global, lowercase-global
+    json_opts = [[
+JSON_OPTIONS
+    ]]
+
+    report_log('Issuing formatting request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    report_log('JSON opts: ' .. json_opts .. '\n') ---@diagnostic disable-line: undefined-global
+
+    local formatting_result = vim.lsp.buf_request_sync(0, 'textDocument/formatting', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        -- Decode the `FormattingOptions` into a lua table
+        ---@diagnostic disable: undefined-global
+        options = vim.json.decode(json_opts)
+        ---@diagnostic enable: undefined-global
+    }, 1000)
+    if formatting_result and #formatting_result >= 1 and formatting_result[1].result and #formatting_result[1].result >= 1 then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        --- NOTE: Does this ever return more than one result? Just use the first for now
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(formatting_result[1].result))
+        results_file:close()
+        vim.cmd('qa!')
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid formatting result returned: ' .. vim.inspect(formatting_result) .. '\n')
+    end
+end

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,7 +12,7 @@ mod tests {
     use serde_json::Map;
 
     use crate::{
-        lspresso_shot, test_completions, test_definition, test_diagnostics, test_formatting,
+        lspresso_shot, test_completion, test_definition, test_diagnostics, test_formatting,
         test_hover, test_references, test_rename,
         types::{CompletionResult, ServerStartType, TestCase, TestFile},
     };
@@ -522,6 +522,6 @@ println!("format {local_variable} arguments");
             .cleanup(false)
             .cursor_pos(Some(Position::new(1, 9)))
             .other_file(cargo_dot_toml());
-        lspresso_shot!(test_completions(completion_test_case, &expected_comps));
+        lspresso_shot!(test_completion(completion_test_case, &expected_comps));
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,8 +12,8 @@ mod tests {
     use serde_json::Map;
 
     use crate::{
-        lspresso_shot, test_completions, test_definition, test_diagnostics, test_hover,
-        test_references, test_rename,
+        lspresso_shot, test_completions, test_definition, test_diagnostics, test_formatting,
+        test_hover, test_references, test_rename,
         types::{CompletionResult, ServerStartType, TestCase, TestFile},
     };
 
@@ -65,6 +65,45 @@ path = "src/main.rs""#,
                     end: Position::new(1, 11)
                 },
             }]
+        ));
+    }
+
+    #[test]
+    fn rust_analyzer_formatting() {
+        let source_file = TestFile::new(
+            "src/main.rs",
+            "pub fn main() {
+let foo = 5;
+}",
+        );
+        let formatting_test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(5).unwrap(),
+                "rustAnalyzer/Indexing".to_string(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .cleanup(false)
+            .other_file(cargo_dot_toml());
+
+        lspresso_shot!(test_formatting(
+            formatting_test_case,
+            None,
+            &vec![
+                TextEdit {
+                    new_text: "    ".to_string(),
+                    range: Range {
+                        start: Position::new(1, 0),
+                        end: Position::new(1, 0),
+                    },
+                },
+                TextEdit {
+                    new_text: "\n".to_string(),
+                    range: Range {
+                        start: Position::new(2, 1),
+                        end: Position::new(2, 1),
+                    }
+                }
+            ],
         ));
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr, time::Duration};
 
     use lsp_types::{
         CodeDescription, CompletionItem, CompletionItemKind, CompletionTextEdit, Diagnostic,
@@ -47,7 +47,7 @@ path = "src/main.rs""#,
         );
         let reference_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                5,
+                NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .cursor_pos(Some(Position::new(1, 9)))
@@ -78,7 +78,7 @@ path = "src/main.rs""#,
         );
         let rename_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                5,
+                NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .cursor_pos(Some(Position::new(1, 9)))
@@ -120,7 +120,7 @@ path = "src/main.rs""#,
         );
         let definition_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                5,
+                NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .cursor_pos(Some(Position::new(2, 5)))
@@ -297,7 +297,7 @@ path = "src/main.rs""#,
         );
         let hover_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                1,
+                NonZeroU32::new(1).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -476,7 +476,7 @@ println!("format {local_variable} arguments");
         );
         let completion_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                4,
+                NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .timeout(Duration::from_secs(20))


### PR DESCRIPTION
This PR adds testing coverage for `textDocument/formatting`, and also includes some cleanup I've been meaning to do for a bit. Because of this the diff if a bit messy, but commit-by-commit things should be pretty straightforward.

Unfortunately, it looks like the threading fix I added in #4 wasn't quite right, as I ran into some issues while testing locally. For now, I've limited the number of conccurent neovim runs to 1. The downside here is that the entire test suite runs slow. Maybe there's another workaround?

~~As a followup, I'd like to extend `test_formatting` to take in an enum for the `expected` parameter, allowing either the expected response edits (which this PR includes) or an expected end state for the document to compare against. That should be relatively easy, but for now, sleep.~~ Done.