### PR TITLE
feat: `textDocument/documentSymbol`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ To start though, let's focus on the following TODOs:
 - [x] `textDocument/completion`
 - [x] `textDocument/formatting`
 - [x] `textDocument/rename`
+- [x] `textDocument/documentSymbol`
 - [ ] Figure out what methods we want to add next.
 
 ## Gotchas

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -38,12 +38,13 @@ pub fn get_init_dot_lua(
     );
     // This is how we actually invoke the action to be tested
     match test_type {
-        TestType::Hover
-        | TestType::Completion
+        TestType::Completion
         | TestType::Definition
+        | TestType::DocumentSymbol
+        | TestType::Formatting
+        | TestType::Hover
         | TestType::References
-        | TestType::Rename
-        | TestType::Formatting => {
+        | TestType::Rename => {
             raw_init = raw_init.replace("LSP_ACTION", &invoke_lsp_action(&test_case.start_type));
         }
         TestType::Diagnostic => {
@@ -104,6 +105,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::Completion => include_str!("lua_templates/completion_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),
         TestType::Diagnostic => "\n-- NOTE: No `check_progress_result` function for diagnostics, instead handled by `DiagnosticChanged` autocmd\n",
+        TestType::DocumentSymbol => include_str!("lua_templates/document_symbol.lua"),
         TestType::Formatting => include_str!("lua_templates/formatting_action.lua"),
         TestType::Hover => include_str!("lua_templates/hover_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -245,7 +245,7 @@ pub fn test_diagnostics(mut test_case: TestCase, expected: &[Diagnostic]) -> Tes
     Ok(())
 }
 
-/// Tests the server's response to a 'textDocument/publishDiagnostics' request
+/// Tests the server's response to a 'textDocument/documentSymbol' request
 ///
 /// # Errors
 ///

--- a/lspresso-shot/lua_templates/document_symbol.lua
+++ b/lspresso-shot/lua_templates/document_symbol.lua
@@ -1,0 +1,37 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    report_log('Issuing document symbol request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local doc_sym_result = vim.lsp.buf_request_sync(0, 'textDocument/documentSymbol', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        ---@diagnostic disable-next-line: undefined-global
+    }, 1000)
+    if doc_sym_result and #doc_sym_result >= 1 and doc_sym_result[1].result then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        for _, sym in ipairs(doc_sym_result[1].result) do
+            if sym.location and sym.location.uri then
+                ---@diagnostic disable-next-line: undefined-global
+                sym.location.uri = extract_relative_path(sym.location.uri)
+            end
+        end
+
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(doc_sym_result[1].result))
+        results_file:close()
+        vim.cmd('qa!')
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid hover result returned: ' .. vim.inspect(doc_sym_result) .. '\n')
+    end
+end

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use anstyle::{AnsiColor, Color, Style};
+use lsp_types::DocumentSymbolResponse;
 pub use lsp_types::{
     CompletionItem, CompletionList, CompletionResponse, Diagnostic, GotoDefinitionResponse, Hover,
     Location, Position, TextEdit, WorkspaceEdit,
@@ -27,6 +28,8 @@ pub enum TestType {
     Definition,
     /// Test `textDocument/publishDiagnostics` requests
     Diagnostic,
+    /// Test `textDocument/documentSymbol` requests
+    DocumentSymbol,
     /// Test `textDocument/formatting` requests
     Formatting,
     /// Test `textDocument/hover` requests
@@ -46,6 +49,7 @@ impl std::fmt::Display for TestType {
                 Self::Completion => "completion",
                 Self::Definition => "definition",
                 Self::Diagnostic => "publishDiagnostics",
+                Self::DocumentSymbol => "documentSymbol",
                 Self::Formatting => "formatting",
                 Self::Hover => "hover",
                 Self::References => "references",
@@ -475,6 +479,8 @@ pub enum TestError {
     #[error(transparent)]
     DiagnosticMismatch(#[from] DiagnosticMismatchError),
     #[error(transparent)]
+    DocumentSymbolMismatch(#[from] DocumentSymbolMismatchError),
+    #[error(transparent)]
     FormattingMismatch(#[from] FormattingMismatchError),
     #[error(transparent)]
     HoverMismatch(#[from] Box<HoverMismatchError>),
@@ -865,6 +871,25 @@ impl std::fmt::Display for DiagnosticMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Diagnostic response:", self.test_id)?;
         write_fields_comparison(f, "Diagnostics", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub struct DocumentSymbolMismatchError {
+    pub test_id: String,
+    pub expected: DocumentSymbolResponse,
+    pub actual: DocumentSymbolResponse,
+}
+
+impl std::fmt::Display for DocumentSymbolMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Document Symbol response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Document Symbols", &self.expected, &self.actual, 0)?;
         Ok(())
     }
 }

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -168,7 +168,7 @@ pub fn handle_request(req: Request, connection: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Sends response to a `textDocument/completion` request
+/// Sends response to a `textDocument/documentSymbol` request
 ///
 /// # Errors
 ///

--- a/test-server/src/lib.rs
+++ b/test-server/src/lib.rs
@@ -1,3 +1,8 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use lsp_types::Uri;
+
 pub mod handle;
 pub mod responses;
 
@@ -5,4 +10,60 @@ pub mod responses;
 #[must_use]
 pub fn get_source_path() -> String {
     "main.dummy".to_string()
+}
+
+/// Given a `URI` pointing to *some* file within an lspresso-shot
+/// test directory, returns the test directory's root path
+///
+/// For example, "/tmp/lspresso-shot/5382805252853875543/src/main.dummy"
+/// would get transformed into /tmp/lspresso-shot/5382805252853875543/"
+///
+/// Since we want to avoid circular dependencies, this is a bit
+/// of a hack rather than using functionality from the lib itself
+pub fn get_root_test_path(uri: &Uri) -> Option<PathBuf> {
+    let lspresso = "lspresso-shot";
+    let uri_str = uri.path().to_string();
+    let mut lspresso_idx = uri_str.find(lspresso)?;
+    lspresso_idx += lspresso.len() + 1; // +1 to account for path separator
+    let end_idx = uri_str
+        .chars()
+        .enumerate()
+        .skip(lspresso_idx)
+        .find(|(_, c)| !c.is_ascii_digit())
+        .map(|(i, _)| i)?;
+
+    let uri: String = uri_str.chars().take(end_idx).collect();
+    Some(uri.into())
+}
+
+// NOTE: This could also be accomplished by adding the file as an "other file"
+// with path `../RESPONSE_NUM.txt` to the test case, but this seems a bit
+// brittle and much less explicit.
+/// Writes `response_num` to `path/RESPONSE_NUM.txt`
+///
+///
+/// # Errors
+///
+/// Will return `std::io::Error` if writing the file fails
+pub fn send_response_num(response_num: u32, path: &Path) -> std::io::Result<()> {
+    let mut path = path.to_path_buf();
+    path.push("RESPONSE_NUM.txt");
+
+    std::fs::write(path, response_num.to_string())
+}
+
+/// Reads a response number from `path/RESPONSE_NUM.txt`
+///
+/// # Errors
+///
+/// Will return `Err` if reading or parsing the file fails
+pub fn receive_response_num(path: &Path) -> Result<u32> {
+    let mut path = path.to_path_buf();
+    path.push("RESPONSE_NUM.txt");
+    let response_str = std::fs::read_to_string(path)?;
+
+    match response_str.parse::<u32>() {
+        Ok(num) => Ok(num),
+        Err(e) => Err(anyhow!("Failed to parse response num contents -- {e}")),
+    }
 }

--- a/test-server/src/lib.rs
+++ b/test-server/src/lib.rs
@@ -41,7 +41,6 @@ pub fn get_root_test_path(uri: &Uri) -> Option<PathBuf> {
 // brittle and much less explicit.
 /// Writes `response_num` to `path/RESPONSE_NUM.txt`
 ///
-///
 /// # Errors
 ///
 /// Will return `std::io::Error` if writing the file fails

--- a/test-server/src/main.rs
+++ b/test-server/src/main.rs
@@ -48,6 +48,7 @@ pub fn main() -> Result<()> {
         ..Default::default()
     });
     let document_formatting_provider = Some(OneOf::Left(true));
+    let document_symbol_provider = Some(OneOf::Left(true));
     let hover_provider = Some(HoverProviderCapability::Simple(true));
     let references_provider = Some(OneOf::Left(true));
     let rename_provider = Some(OneOf::Left(true));
@@ -59,6 +60,7 @@ pub fn main() -> Result<()> {
         definition_provider,
         diagnostic_provider,
         document_formatting_provider,
+        document_symbol_provider,
         hover_provider,
         references_provider,
         rename_provider,

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -413,6 +413,7 @@ pub fn get_references_response(response_num: u32) -> Option<Vec<Location>> {
 #[allow(clippy::missing_panics_doc)]
 pub fn get_formatting_response(response_num: u32) -> Option<Vec<TextEdit>> {
     match response_num {
+        // NOTE: The dummy tests rely on a `response_num` of 0 to return an empty edit response
         0 => Some(vec![]),
         1 => Some(vec![TextEdit {
             range: Range {

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -3,12 +3,56 @@ use std::{collections::HashMap, str::FromStr};
 use lsp_types::{
     ChangeAnnotation, CodeDescription, CompletionItem, CompletionItemKind,
     CompletionItemLabelDetails, CompletionList, CompletionResponse, Diagnostic,
-    DiagnosticRelatedInformation, DocumentChanges, Documentation, GotoDefinitionResponse, Hover,
-    HoverContents, LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind,
-    Position, PublishDiagnosticsParams, Range, TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+    DiagnosticRelatedInformation, DocumentChanges, DocumentSymbol, DocumentSymbolResponse,
+    Documentation, GotoDefinitionResponse, Hover, HoverContents, LanguageString, Location,
+    LocationLink, MarkedString, MarkupContent, MarkupKind, Position, PublishDiagnosticsParams,
+    Range, SymbolInformation, SymbolKind, SymbolTag, TextDocumentEdit, TextEdit, Uri,
+    WorkspaceEdit,
 };
 
 use crate::get_source_path;
+
+/// For use with `test_doucment_symbol`.
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn get_document_symbol_response(response_num: u32) -> Option<DocumentSymbolResponse> {
+    #[allow(deprecated)]
+    match response_num {
+        0 => Some(DocumentSymbolResponse::Flat(vec![])),
+        1 => Some(DocumentSymbolResponse::Nested(vec![])),
+        2 => Some(DocumentSymbolResponse::Flat(vec![SymbolInformation {
+            name: "symbol name 1".to_string(),
+            kind: SymbolKind::FILE,
+            tags: None,
+            deprecated: None,
+            location: Location {
+                uri: Uri::from_str(&get_source_path()).unwrap(),
+                range: Range {
+                    start: Position::new(0, 1),
+                    end: Position::new(2, 3),
+                },
+            },
+            container_name: Some("container name 1".to_string()),
+        }])),
+        3 => Some(DocumentSymbolResponse::Nested(vec![DocumentSymbol {
+            name: "symbol name 2".to_string(),
+            detail: Some("detail".to_string()),
+            kind: SymbolKind::FUNCTION,
+            tags: Some(vec![SymbolTag::DEPRECATED]),
+            deprecated: Some(true),
+            range: Range {
+                start: Position::new(4, 5),
+                end: Position::new(6, 7),
+            },
+            selection_range: Range {
+                start: Position::new(5, 6),
+                end: Position::new(7, 8),
+            },
+            children: Some(vec![]),
+        }])),
+        _ => None,
+    }
+}
 
 /// For use with `test_completion`.
 #[must_use]


### PR DESCRIPTION
This required a little trickery since we couldn't encode `response_num` in the `textDocument/documentSymbol` params like the other requests. I've worked around this by just writing the number to a known file location in the test case's root directory (i.e. /tmp/lspresso-shot/<test-id>/RESPONSE_NUM.txt). This approach feels a lot less hacky than the other way (i.e. adding the response number as the first position parameter's line number). 

~~It may make sense to just use this approach universally for the other dummy test types.~~ Done

Followup for this PR or maybe another one is to apply the shared file approach to allow multiple dummy inputs for diagnostics tests.