### PR TITLE
WIP: allow empty results for some requests

### DIFF
--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -81,6 +81,9 @@ impl Drop for RunnerGuard<'_> {
     }
 }
 
+// TODO: Consider allowing some "allow empty" flag to be passed in for
+// potentially empty types. If `true`, we don't deserialize if the results file
+// is empty, and instead manually pass in our own handmade empty struct
 fn test_inner<R>(test_case: &TestCase, replacements: Option<&Vec<(&str, String)>>) -> TestResult<R>
 where
     R: serde::de::DeserializeOwned,

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -230,7 +230,12 @@ pub fn test_definition(
 // since diagnostics are requested via a `textDocument/publishDiagnostics` notification instead
 // of a request. The `vim.lsp.buf_notify` method only returns a boolean to indicate success,
 // so we can't access the actual data.
-/// Tests the server's response to a 'textDocument/publishDiagnostics' request
+/// Tests the server's response to a 'textDocument/publishDiagnostics' request.
+///
+/// Specifying a `ServerStartType::Progress` for a diagnostics test is overloaded to
+/// determine which `DiagnosticChanged` autocmd to use. This can be useful if your
+/// server sends multiple `textDocument/publishDiagnostics` notifications before
+/// fully analyzing a source file.
 ///
 /// # Errors
 ///

--- a/lspresso-shot/lua_templates/completion_action.lua
+++ b/lspresso-shot/lua_templates/completion_action.lua
@@ -13,8 +13,7 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global
         SET_CURSOR_POSITION,
     }, 1000)
-    if completion_result and #completion_result >= 1 and completion_result[1].result
-        and (completion_result[1].result.items or #completion_result[1].result >= 1) then
+    if completion_result and #completion_result >= 1 and completion_result[1].result then
         local results_file = io.open('RESULTS_FILE', "w")
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global

--- a/lspresso-shot/lua_templates/definition_action.lua
+++ b/lspresso-shot/lua_templates/definition_action.lua
@@ -13,8 +13,7 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global
         SET_CURSOR_POSITION,
     }, 1000)
-    if definition_results and #definition_results > 0 and definition_results[1].result
-        and (#definition_results[1].result > 0 or definition_results[1].result.uri) then
+    if definition_results and #definition_results > 0 and definition_results[1].result then
         local results_file = io.open('RESULTS_FILE', "w")
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global

--- a/lspresso-shot/lua_templates/diagnostic_autocmd.lua
+++ b/lspresso-shot/lua_templates/diagnostic_autocmd.lua
@@ -3,9 +3,13 @@ local progress_count = 0 -- track how many times we've tried for the logs
 vim.api.nvim_create_autocmd('DiagnosticChanged', {
     callback = function(_)
         progress_count = progress_count + 1
-        report_log('Issuing hover request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+        if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+            report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+            return
+        end
+        report_log('Issuing diagnostic request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
         local diagnostics_result = vim.diagnostic.get(0, {})
-        if diagnostics_result and #diagnostics_result >= 1 then
+        if diagnostics_result then
             local results_file = io.open('RESULTS_FILE', 'w')
             if not results_file then
                 report_error('Could not open results file') ---@diagnostic disable-line: undefined-global

--- a/lspresso-shot/lua_templates/formatting_action.lua
+++ b/lspresso-shot/lua_templates/formatting_action.lua
@@ -40,7 +40,7 @@ JSON_OPTIONS
             textDocument = vim.lsp.util.make_text_document_params(0),
             options = format_opts
         }, 1000)
-        if formatting_result and #formatting_result >= 1 and formatting_result[1].result and #formatting_result[1].result >= 1 then
+        if formatting_result and #formatting_result >= 1 and formatting_result[1].result then
             local results_file = io.open('RESULTS_FILE', 'w')
             if not results_file then
                 report_error('Could not open results file') ---@diagnostic disable-line: undefined-global

--- a/lspresso-shot/lua_templates/references_action.lua
+++ b/lspresso-shot/lua_templates/references_action.lua
@@ -15,7 +15,7 @@ local function check_progress_result()
         SET_CONTEXT
         ---@diagnostic enable: undefined-global
     }, 1000)
-    if reference_result and #reference_result >= 1 and reference_result[1].result and #reference_result[1].result >= 1 then
+    if reference_result and #reference_result >= 1 and reference_result[1].result then
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             ---@diagnostic disable-next-line: undefined-global

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -511,7 +511,7 @@ pub enum TestError {
     #[error("Test {0}: UTF8 Error\n{1}")]
     Utf8(String, String),
     #[error("Test {0}: Serialization Error\n{1}")]
-    Serialization(String, String),
+    Serialization(String, serde_json::Error),
     #[error(transparent)]
     TimeoutExceeded(TimeoutError),
 }

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -317,7 +317,7 @@ pub fn get_definition_response(response_num: u32) -> Option<GotoDefinitionRespon
 pub fn get_rename_response(response_num: u32) -> Option<WorkspaceEdit> {
     match response_num {
         0 => Some(WorkspaceEdit {
-            changes: None,
+            changes: Some(HashMap::new()),
             document_changes: None,
             change_annotations: None,
         }),
@@ -350,7 +350,12 @@ pub fn get_rename_response(response_num: u32) -> Option<WorkspaceEdit> {
             }])),
             change_annotations: None,
         }),
-        3 => {
+        3 => Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![])),
+            change_annotations: None,
+        }),
+        4 => {
             let mut changes = HashMap::new();
             changes.insert(
                 get_source_path(),
@@ -366,6 +371,11 @@ pub fn get_rename_response(response_num: u32) -> Option<WorkspaceEdit> {
                 change_annotations: Some(changes),
             })
         }
+        5 => Some(WorkspaceEdit {
+            changes: None,
+            document_changes: None,
+            change_annotations: Some(HashMap::new()),
+        }),
         _ => None,
     }
 }

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -106,22 +106,27 @@ pub fn get_completion_response(response_num: u32) -> Option<CompletionResponse> 
     match response_num {
         0 => Some(CompletionResponse::List(CompletionList {
             is_incomplete: true,
-            items: vec![item1],
+            items: vec![],
         })),
         1 => Some(CompletionResponse::List(CompletionList {
             is_incomplete: true,
-            items: vec![item1, item2],
+            items: vec![item1],
         })),
         2 => Some(CompletionResponse::List(CompletionList {
-            is_incomplete: false,
-            items: vec![item1],
+            is_incomplete: true,
+            items: vec![item1, item2],
         })),
         3 => Some(CompletionResponse::List(CompletionList {
             is_incomplete: false,
+            items: vec![item1],
+        })),
+        4 => Some(CompletionResponse::List(CompletionList {
+            is_incomplete: false,
             items: vec![item1, item2],
         })),
-        4 => Some(CompletionResponse::Array(vec![item1])),
-        5 => Some(CompletionResponse::Array(vec![item1, item2])),
+        5 => Some(CompletionResponse::Array(vec![])),
+        6 => Some(CompletionResponse::Array(vec![item1])),
+        7 => Some(CompletionResponse::Array(vec![item1, item2])),
         _ => None,
     }
 }

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -188,17 +188,24 @@ pub fn get_hover_response(response_num: u32) -> Option<Hover> {
         //     }),
         // }),
         4 => Some(Hover {
+            contents: HoverContents::Array(vec![]),
+            range: Some(Range {
+                start: Position::new(17, 18),
+                end: Position::new(19, 20),
+            }),
+        }),
+        5 => Some(Hover {
             contents: HoverContents::Array(vec![
                 MarkedString::String("Array Marked String 1\nExtra".to_string()),
                 MarkedString::String("Array Marked String 2\nExtra extra".to_string()),
                 MarkedString::String("Array Marked String 3\nJust kidding".to_string()),
             ]),
             range: Some(Range {
-                start: Position::new(13, 14),
-                end: Position::new(15, 16),
+                start: Position::new(21, 22),
+                end: Position::new(23, 24),
             }),
         }),
-        5 => Some(Hover {
+        6 => Some(Hover {
             contents: HoverContents::Array(vec![
                 MarkedString::LanguageString(LanguageString {
                     language: "dummy-lang".to_string(),

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -289,17 +289,19 @@ pub fn get_definition_response(response_num: u32) -> Option<GotoDefinitionRespon
         }),
     };
     match response_num {
-        0 => Some(GotoDefinitionResponse::Scalar(location_item)),
+        0 => Some(GotoDefinitionResponse::Array(vec![])),
         1 => Some(GotoDefinitionResponse::Array(vec![location_item])),
         2 => Some(GotoDefinitionResponse::Array(vec![
             location_item.clone(),
             location_item,
         ])),
-        3 => Some(GotoDefinitionResponse::Link(vec![link_item])),
-        4 => Some(GotoDefinitionResponse::Link(vec![
+        3 => Some(GotoDefinitionResponse::Link(vec![])),
+        4 => Some(GotoDefinitionResponse::Link(vec![link_item])),
+        5 => Some(GotoDefinitionResponse::Link(vec![
             link_item.clone(),
             link_item,
         ])),
+        6 => Some(GotoDefinitionResponse::Scalar(location_item)),
         _ => None,
     }
 }

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -22,7 +22,7 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_definition_simple(#[values(0, 1, 2, 3, 4)] response_num: u32) {
+    fn test_server_definition_simple(#[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32) {
         let resp = test_server::responses::get_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_source_path(), "");
         let definition_test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/diagnostics.rs
+++ b/test-suite/src/diagnostics.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr as _, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::cargo_dot_toml;
     use lspresso_shot::{
         lspresso_shot, test_diagnostics,
-        types::{TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -34,7 +34,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_server_diagnostics(#[values(1, 2)] response_num: u32) {
+    fn test_server_diagnostics(#[values(0, 1, 2)] response_num: u32) {
         let uri = Uri::from_str(&test_server::get_source_path()).unwrap();
         let resp = test_server::responses::get_diagnostics_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_source_path(), "");
@@ -50,7 +50,6 @@ mod tests {
         lspresso_shot!(test_diagnostics(test_case, &resp.diagnostics));
     }
 
-    // NOTE:: Specifying the start type is ignored for diagnostics tests
     #[test]
     fn rust_analyzer_multi_diagnostics() {
         let source_file = TestFile::new(
@@ -60,6 +59,10 @@ mod tests {
 }",
         );
         let diagnostic_test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(2).unwrap(),
+                String::new(),
+            ))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
@@ -130,6 +133,10 @@ mod tests {
 }"#,
         );
         let diagnostic_test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(2).unwrap(),
+                String::new(),
+            ))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 

--- a/test-suite/src/formatting.rs
+++ b/test-suite/src/formatting.rs
@@ -40,7 +40,7 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_formatting_response_simple(#[values(1, 2, 3)] response_num: u32) {
+    fn test_server_formatting_response_simple(#[values(0, 1, 2, 3)] response_num: u32) {
         let edits = test_server::responses::get_formatting_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_source_path(), "Some source contents");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);

--- a/test-suite/src/references.rs
+++ b/test-suite/src/references.rs
@@ -20,7 +20,7 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_references_simple(#[values(1, 2, 3)] response_num: u32) {
+    fn test_server_references_simple(#[values(0, 1, 2, 3)] response_num: u32) {
         let refs = test_server::responses::get_references_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/rename.rs
+++ b/test-suite/src/rename.rs
@@ -23,7 +23,7 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_rename_simple(#[values(1, 2, 3)] response_num: u32) {
+    fn test_server_rename_simple(#[values(0, 1, 2, 3, 4, 5)] response_num: u32) {
         let edits = test_server::responses::get_rename_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)


### PR DESCRIPTION
Since the improvements to our handling of `$/progress`-style LSPs, we should (in theory) be able to handle "empty" results correctly. This now works for any valid response type with some type of container that can be empty (a `Vec` or `Hashmap`). As a followup, I'd like to investigate how well we can handle cases where a client returns `None` as a result type. Accepting `Option<T>` for all of the `test_*` functions seems like it would complicate our logic quite a bit, but I'll spend some time seeing if there's a clean way to do this in a followup.

Checklist:

- [x] formatting
- [x] references
- [x] rename
- [x] hover
- [x] document symbol
- [x] diagnostic
- [x] definition
- [x] completion

