### PR TITLE
fix: handle no response from server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn it_does_the_hover_thing() {
 
     lspresso_shot!(test_hover(
         hover_test_case,
-        Hover {
+        Some(&Hover {
             range: Some(Range {
                 start: lsp_types::Position {
                     line: 1,
@@ -49,7 +49,7 @@ fn it_does_the_hover_thing() {
                 kind: lsp_types::MarkupKind::Markdown,
                 value: "Hover window contents here".to_string(),
             })
-        }
+        })
     ));
 }
 ```

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -11,6 +11,7 @@ pub fn get_init_dot_lua(
     let root_path = test_case.get_lspresso_dir()?;
     let error_path = test_case.get_error_file_path()?;
     let log_path = test_case.get_log_file_path()?;
+    let empty_path = test_case.get_empty_file_path()?;
     let source_extension = test_case
         .source_file
         .path
@@ -75,6 +76,7 @@ pub fn get_init_dot_lua(
         .replace("ROOT_PATH", root_path.to_str().unwrap())
         .replace("ERROR_PATH", error_path.to_str().unwrap())
         .replace("LOG_PATH", log_path.to_str().unwrap())
+        .replace("EMPTY_PATH", empty_path.to_str().unwrap())
         .replace("FILE_EXTENSION", source_extension)
         .replace("SET_CURSOR_POSITION", &set_cursor_position)
         .replace(

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -81,13 +81,54 @@ impl Drop for RunnerGuard<'_> {
     }
 }
 
-// TODO: Consider allowing some "allow empty" flag to be passed in for
-// potentially empty types. If `true`, we don't deserialize if the results file
-// is empty, and instead manually pass in our own handmade empty struct
-fn test_inner<R>(test_case: &TestCase, replacements: Option<&Vec<(&str, String)>>) -> TestResult<R>
+trait Empty {
+    fn is_empty() -> bool {
+        false
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EmptyResult {}
+
+impl Empty for EmptyResult {
+    fn is_empty() -> bool {
+        true
+    }
+}
+
+impl Empty for CompletionResponse {}
+impl Empty for DocumentSymbolResponse {}
+impl Empty for FormattingResult {}
+impl Empty for GotoDefinitionResponse {}
+impl Empty for Hover {}
+impl Empty for String {}
+impl Empty for Vec<Diagnostic> {}
+impl Empty for Vec<Location> {}
+impl Empty for Vec<TextEdit> {}
+impl Empty for WorkspaceEdit {}
+
+/// This handles the validating the test case, running the test, and gathering/deserializing
+/// results.
+///
+/// If `R` is `Empty`, we expect empty results and this will only return `Err`
+/// or `Ok(None)`. Otherwise, we expect some results, and this function will return
+/// `Ok(Some(_))` or `Err`.
+fn test_inner<R>(
+    test_case: &TestCase,
+    replacements: Option<&Vec<(&str, String)>>,
+) -> TestResult<Option<R>>
 where
-    R: serde::de::DeserializeOwned,
+    R: serde::de::DeserializeOwned + Empty + std::fmt::Debug,
 {
+    let get_results = |path: &Path| -> TestResult<R> {
+        let raw_results = String::from_utf8(
+            fs::read(path).map_err(|e| TestError::IO(test_case.test_id.clone(), e))?,
+        )
+        .map_err(|e| TestError::Utf8(test_case.test_id.clone(), e))?;
+        let actual: R = serde_json::from_str(&raw_results)
+            .map_err(|e| TestError::Serialization(test_case.test_id.clone(), e))?;
+        Ok(actual)
+    };
     test_case.validate()?;
     // Invariant: `test_case.test_type` should always be set to `Some(_)` in the caller
     let source_path = test_case.create_test(
@@ -96,23 +137,44 @@ where
     )?;
     run_test(test_case, &source_path)?;
 
+    let empty_result_path = test_case
+        .get_empty_file_path()
+        .map_err(|e| TestError::IO(test_case.test_id.clone(), e))?;
     let results_file_path = test_case
         .get_results_file_path()
-        .map_err(|e| TestError::IO(test_case.test_id.clone(), e.to_string()))?;
-    if !results_file_path.exists() {
-        Err(TestError::NoResults(test_case.test_id.clone()))?;
+        .map_err(|e| TestError::IO(test_case.test_id.clone(), e))?;
+
+    match (
+        R::is_empty(),
+        empty_result_path.exists(),
+        results_file_path.exists(),
+    ) {
+        // Expected and got empty results
+        (true, true, false) => Ok(None),
+        // Expected empty results, got some
+        (true, false, true) => {
+            let results: TestResult<R> = get_results(&results_file_path);
+            let actual_str = match results {
+                Ok(res) => format!("{res:#?}"),
+                Err(e) => format!("Invalid results: {e}"),
+            };
+            Err(TestError::ExpectedNone(
+                test_case.test_id.clone(),
+                actual_str,
+            ))?
+        }
+        // Invariant: `results.json` and `empty` should never both exist
+        (true | false, true, true) => unreachable!(),
+        // No results
+        (true | false, false, false) => Err(TestError::NoResults(test_case.test_id.clone()))?,
+        // Expected some results, got none
+        (false, true, false) => Err(TestError::ExpectedSome(test_case.test_id.clone()))?,
+        // Expected and got some results
+        (false, false, true) => {
+            let actual: R = get_results(&results_file_path)?;
+            Ok(Some(actual))
+        }
     }
-    let raw_results = String::from_utf8(
-        fs::read(&results_file_path)
-            .map_err(|e| TestError::IO(test_case.test_id.clone(), e.to_string()))?,
-    )
-    .map_err(|e| TestError::Utf8(test_case.test_id.clone(), e.to_string()))?;
-    let actual: R = serde_json::from_str(&raw_results)
-        .map_err(|e| TestError::Serialization(test_case.test_id.clone(), e))?;
-
-    test_case.do_cleanup();
-
-    Ok(actual)
 }
 
 /// Invokes neovim to run the test with `test_case`'s associated `init.lua` file,
@@ -120,7 +182,7 @@ where
 fn run_test(test_case: &TestCase, source_path: &Path) -> TestResult<()> {
     let init_dot_lua_path = test_case
         .get_init_lua_file_path()
-        .map_err(|e| TestError::IO(test_case.test_id.clone(), e.to_string()))?;
+        .map_err(|e| TestError::IO(test_case.test_id.clone(), e))?;
 
     // Restrict the number of tests invoking neovim at a given time to prevent timeout issues
     let (lock, cvar) = &*get_runner_count();
@@ -152,10 +214,10 @@ fn run_test(test_case: &TestCase, source_path: &Path) -> TestResult<()> {
     // than the timeout
     let error_path = test_case
         .get_error_file_path()
-        .map_err(|e| TestError::IO(test_case.test_id.clone(), e.to_string()))?;
+        .map_err(|e| TestError::IO(test_case.test_id.clone(), e))?;
     if error_path.exists() {
         let error = fs::read_to_string(&error_path)
-            .map_err(|e| TestError::IO(test_case.test_id.clone(), e.to_string()))?;
+            .map_err(|e| TestError::IO(test_case.test_id.clone(), e))?;
         Err(TestError::Neovim(test_case.test_id.clone(), error))?;
     }
 
@@ -165,15 +227,25 @@ fn run_test(test_case: &TestCase, source_path: &Path) -> TestResult<()> {
     }))?
 }
 
-// TODO: We'll need some separate handling for negative cases, e.g. where it's
-// expected for *no* results to be returned. This is tricky because for servers
-// with a `$/progress` style startup, we need to basically poll the server for valid
-// results until we find something. There's no way (that I can tell) to distinguish
-// between an empty "not ready" and a true empty response -- the lua table just looks
-// like this: `{ {} }`
-// Ok it looks like we can reviist this now that `$/progress` handling was updated
-// to look for a sepcific update message rather than polling everytime. I *think*
-// we can get rid of the the checks for empty results, and just return them as is.
+fn collect_results<R1, R2>(
+    test_case: &TestCase,
+    replacements: Option<&Vec<(&str, String)>>,
+    expected: Option<&R1>,
+    cmp: impl Fn(&R1, &R2) -> TestResult<()>,
+) -> TestResult<()>
+where
+    R1: std::fmt::Debug,
+    R2: serde::de::DeserializeOwned + Empty + std::fmt::Debug,
+{
+    if let Some(expected) = expected {
+        let actual: R2 = test_inner(test_case, replacements)?.unwrap();
+        Ok(cmp(expected, &actual)?)
+    } else {
+        let empty = test_inner::<EmptyResult>(test_case, replacements)?;
+        assert!(empty.is_none());
+        Ok(())
+    }
+}
 
 /// Tests the server's response to a 'textDocument/complection' request
 ///
@@ -181,22 +253,25 @@ fn run_test(test_case: &TestCase, source_path: &Path) -> TestResult<()> {
 ///
 /// Returns `TestError` if the test case is invalid, the expected results don't match,
 /// or some other failure occurs
-pub fn test_completion(mut test_case: TestCase, expected: &CompletionResult) -> TestResult<()> {
+pub fn test_completion(
+    mut test_case: TestCase,
+    expected: Option<&CompletionResult>,
+) -> TestResult<()> {
     if test_case.cursor_pos.is_none() {
         Err(TestSetupError::InvalidCursorPosition(TestType::Completion))?;
     }
     test_case.test_type = Some(TestType::Completion);
-    let actual: CompletionResponse = test_inner(&test_case, None)?;
 
-    if !expected.results_satisfy(&actual) {
-        Err(CompletionMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.clone(),
-            actual,
-        })?;
-    }
-
-    Ok(())
+    collect_results(&test_case, None, expected, |expected, actual| {
+        if !expected.results_satisfy(actual) {
+            Err(CompletionMismatchError {
+                test_id: test_case.test_id.clone(),
+                expected: (*expected).clone(),
+                actual: actual.clone(),
+            })?;
+        }
+        Ok(())
+    })
 }
 
 /// Tests the server's response to a 'textDocument/definition' request
@@ -206,36 +281,41 @@ pub fn test_completion(mut test_case: TestCase, expected: &CompletionResult) -> 
 /// Returns `TestError` if the expected results don't match, or if some other failure occurs
 pub fn test_definition(
     mut test_case: TestCase,
-    expected: &GotoDefinitionResponse,
+    expected: Option<&GotoDefinitionResponse>,
 ) -> TestResult<()> {
     if test_case.cursor_pos.is_none() {
         Err(TestSetupError::InvalidCursorPosition(TestType::Definition))?;
     }
     test_case.test_type = Some(TestType::Definition);
-    let actual: GotoDefinitionResponse = test_inner(&test_case, None)?;
-
-    // HACK: Since the `GotoDefinitionResponse` is untagged, there's no way to differentiate
-    // between the `Array` and `Link` if we get an empty vector in response. Just
-    // treat this as a special case and say it's ok.
-    match (expected, &actual) {
-        (GotoDefinitionResponse::Array(array_items), GotoDefinitionResponse::Link(link_items))
-        | (GotoDefinitionResponse::Link(link_items), GotoDefinitionResponse::Array(array_items)) => {
-            if array_items.is_empty() && link_items.is_empty() {
-                return Ok(());
+    collect_results(&test_case, None, expected, |expected, actual| {
+        // HACK: Since the `GotoDefinitionResponse` is untagged, there's no way to differentiate
+        // between the `Array` and `Link` if we get an empty vector in response. Just
+        // treat this as a special case and say it's ok.
+        match (expected, actual) {
+            (
+                GotoDefinitionResponse::Array(array_items),
+                GotoDefinitionResponse::Link(link_items),
+            )
+            | (
+                GotoDefinitionResponse::Link(link_items),
+                GotoDefinitionResponse::Array(array_items),
+            ) => {
+                if array_items.is_empty() && link_items.is_empty() {
+                    return Ok(());
+                }
             }
+            _ => {}
         }
-        _ => {}
-    }
 
-    if *expected != actual {
-        Err(Box::new(DefinitionMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.clone(),
-            actual,
-        }))?;
-    }
-
-    Ok(())
+        if *expected != *actual {
+            Err(Box::new(DefinitionMismatchError {
+                test_id: test_case.test_id.clone(),
+                expected: expected.clone(),
+                actual: actual.clone(),
+            }))?;
+        }
+        Ok(())
+    })
 }
 
 // NOTE: As far as I can tell, we can't directly accept a `PublishDiagnosticsParams` object,
@@ -253,18 +333,26 @@ pub fn test_definition(
 ///
 /// Returns `TestError` if the test case is invalid, the expected results don't match,
 /// or some other failure occurs
-pub fn test_diagnostics(mut test_case: TestCase, expected: &[Diagnostic]) -> TestResult<()> {
+pub fn test_diagnostics(
+    mut test_case: TestCase,
+    expected: Option<&Vec<Diagnostic>>,
+) -> TestResult<()> {
     test_case.test_type = Some(TestType::Diagnostic);
-    let actual: Vec<Diagnostic> = test_inner(&test_case, None)?;
-    if expected != actual {
-        Err(DiagnosticMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.to_vec(),
-            actual,
-        })?;
-    }
-
-    Ok(())
+    collect_results(
+        &test_case,
+        None,
+        expected,
+        |expected: &Vec<Diagnostic>, actual: &Vec<Diagnostic>| {
+            if expected != actual {
+                Err(DiagnosticMismatchError {
+                    test_id: test_case.test_id.clone(),
+                    expected: expected.clone(),
+                    actual: actual.clone(),
+                })?;
+            }
+            Ok(())
+        },
+    )
 }
 
 /// Tests the server's response to a 'textDocument/documentSymbol' request
@@ -275,38 +363,38 @@ pub fn test_diagnostics(mut test_case: TestCase, expected: &[Diagnostic]) -> Tes
 /// or some other failure occurs
 pub fn test_document_symbol(
     mut test_case: TestCase,
-    expected: &DocumentSymbolResponse,
+    expected: Option<&DocumentSymbolResponse>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::DocumentSymbol);
-    let actual: DocumentSymbolResponse = test_inner(&test_case, None)?;
-
-    // HACK: Since the two types of DocumentSymbolResponse are untagged, there's no
-    // way to differentiate between the two if we get an empty vector in response.
-    // Just treat this as a special case and say it's ok.
-    match (expected, &actual) {
-        (
-            DocumentSymbolResponse::Flat(flat_items),
-            DocumentSymbolResponse::Nested(nested_items),
-        )
-        | (
-            DocumentSymbolResponse::Nested(nested_items),
-            DocumentSymbolResponse::Flat(flat_items),
-        ) => {
-            if flat_items.is_empty() && nested_items.is_empty() {
-                return Ok(());
+    collect_results(&test_case, None, expected, |expected, actual| {
+        // HACK: Since the two types of DocumentSymbolResponse are untagged, there's no
+        // way to differentiate between the two if we get an empty vector in response.
+        // Just treat this as a special case and say it's ok.
+        match (expected, actual) {
+            (
+                DocumentSymbolResponse::Flat(flat_items),
+                DocumentSymbolResponse::Nested(nested_items),
+            )
+            | (
+                DocumentSymbolResponse::Nested(nested_items),
+                DocumentSymbolResponse::Flat(flat_items),
+            ) => {
+                if flat_items.is_empty() && nested_items.is_empty() {
+                    return Ok(());
+                }
             }
+            _ => {}
         }
-        _ => {}
-    }
-    if *expected != actual {
-        Err(DocumentSymbolMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.clone(),
-            actual,
-        })?;
-    }
+        if expected != actual {
+            Err(DocumentSymbolMismatchError {
+                test_id: test_case.test_id.clone(),
+                expected: expected.clone(),
+                actual: actual.clone(),
+            })?;
+        }
 
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Tests the server's response to a 'textDocument/formatting' request. If `options`
@@ -333,7 +421,7 @@ pub fn test_document_symbol(
 pub fn test_formatting(
     mut test_case: TestCase,
     options: Option<FormattingOptions>,
-    expected: &FormattingResult,
+    expected: Option<&FormattingResult>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::Formatting);
     let opts = options.unwrap_or_else(|| FormattingOptions {
@@ -346,33 +434,62 @@ pub fn test_formatting(
     });
     let json_opts = serde_json::to_string_pretty(&opts)
         .expect("JSON deserialzation of formatting options failed");
-
-    let actual: FormattingResult = match expected {
-        FormattingResult::Response(_) => FormattingResult::Response(test_inner::<Vec<TextEdit>>(
+    match expected {
+        Some(FormattingResult::Response(edits)) => collect_results(
             &test_case,
             Some(&vec![
                 ("INVOKE_FORMAT", "false".to_string()),
                 ("JSON_OPTIONS", json_opts),
             ]),
-        )?),
-        FormattingResult::EndState(_) => FormattingResult::EndState(test_inner::<String>(
+            Some(edits),
+            |expected, actual: &Vec<TextEdit>| {
+                if expected != actual {
+                    Err(FormattingMismatchError {
+                        test_id: test_case.test_id.clone(),
+                        expected: FormattingResult::Response(expected.clone()),
+                        actual: FormattingResult::Response(actual.clone()),
+                    })?;
+                }
+                Ok(())
+            },
+        ),
+        Some(FormattingResult::EndState(state)) => collect_results(
             &test_case,
             Some(&vec![
                 ("INVOKE_FORMAT", "true".to_string()),
                 ("JSON_OPTIONS", json_opts),
             ]),
-        )?),
-    };
-
-    if *expected != actual {
-        Err(FormattingMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.clone(),
-            actual,
-        })?;
+            Some(state),
+            |expected, actual: &String| {
+                if expected != actual {
+                    Err(FormattingMismatchError {
+                        test_id: test_case.test_id.clone(),
+                        expected: FormattingResult::EndState(expected.clone()),
+                        actual: FormattingResult::EndState(actual.clone()),
+                    })?;
+                }
+                Ok(())
+            },
+        ),
+        None => collect_results(
+            &test_case,
+            Some(&vec![
+                ("INVOKE_FORMAT", "false".to_string()),
+                ("JSON_OPTIONS", json_opts),
+            ]),
+            None,
+            |expected: &Vec<TextEdit>, actual: &Vec<TextEdit>| {
+                if expected != actual {
+                    Err(FormattingMismatchError {
+                        test_id: test_case.test_id.clone(),
+                        expected: FormattingResult::Response(expected.clone()),
+                        actual: FormattingResult::Response(actual.clone()),
+                    })?;
+                }
+                Ok(())
+            },
+        ),
     }
-
-    Ok(())
 }
 
 /// Tests the server's response to a 'textDocument/hover' request
@@ -381,22 +498,21 @@ pub fn test_formatting(
 ///
 /// Returns `TestError` if the test case is invalid, the expected results don't match,
 /// or some other failure occurs
-pub fn test_hover(mut test_case: TestCase, expected: Hover) -> TestResult<()> {
+pub fn test_hover(mut test_case: TestCase, expected: Option<&Hover>) -> TestResult<()> {
     if test_case.cursor_pos.is_none() {
         Err(TestSetupError::InvalidCursorPosition(TestType::Hover))?;
     }
     test_case.test_type = Some(TestType::Hover);
-    let actual = test_inner(&test_case, None)?;
-
-    if expected != actual {
-        Err(Box::new(HoverMismatchError {
-            test_id: test_case.test_id,
-            expected,
-            actual,
-        }))?;
-    }
-
-    Ok(())
+    collect_results(&test_case, None, expected, |expected, actual| {
+        if expected != actual {
+            Err(Box::new(HoverMismatchError {
+                test_id: test_case.test_id.clone(),
+                expected: expected.clone(),
+                actual: actual.clone(),
+            }))?;
+        }
+        Ok(())
+    })
 }
 
 /// Tests the server's response to a 'textDocument/references' request
@@ -407,29 +523,30 @@ pub fn test_hover(mut test_case: TestCase, expected: Hover) -> TestResult<()> {
 pub fn test_references(
     mut test_case: TestCase,
     include_declaration: bool,
-    expected: &Vec<Location>,
+    expected: Option<&Vec<Location>>,
 ) -> TestResult<()> {
     if test_case.cursor_pos.is_none() {
         Err(TestSetupError::InvalidCursorPosition(TestType::References))?;
     }
     test_case.test_type = Some(TestType::References);
-    let actual: Vec<Location> = test_inner(
+    collect_results(
         &test_case,
         Some(&vec![(
             "SET_CONTEXT",
             format!("context = {{ includeDeclaration = {include_declaration} }}"),
         )]),
-    )?;
-
-    if *expected != actual {
-        Err(ReferencesMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.clone(),
-            actual,
-        })?;
-    }
-
-    Ok(())
+        expected,
+        |expected, actual: &Vec<Location>| {
+            if expected != actual {
+                Err(ReferencesMismatchError {
+                    test_id: test_case.test_id.clone(),
+                    expected: expected.clone(),
+                    actual: actual.clone(),
+                })?;
+            }
+            Ok(())
+        },
+    )
 }
 
 /// Tests the server's response to a 'textDocument/rename' request
@@ -437,53 +554,65 @@ pub fn test_references(
 /// # Errors
 ///
 /// Returns `TestError` if the expected results don't match, or if some other failure occurs
+#[allow(clippy::missing_panics_doc)]
 pub fn test_rename(
     mut test_case: TestCase,
     new_name: &str,
-    expected: &WorkspaceEdit,
+    expected: Option<&WorkspaceEdit>,
 ) -> TestResult<()> {
     if test_case.cursor_pos.is_none() {
         Err(TestSetupError::InvalidCursorPosition(TestType::Rename))?;
     }
     test_case.test_type = Some(TestType::Rename);
-    let actual = match test_inner::<WorkspaceEdit>(
-        &test_case,
-        Some(&vec![("NEW_NAME", format!("newName = '{new_name}'"))]),
-    ) {
-        Ok(edits) => edits,
-        Err(TestError::Serialization(test_id, e)) => {
-            // HACK: Comparing against the stringified error is rather hacky,
-            // but the error object's `code` field isn't accessible. In this case,
-            // we return the expected object
-            let e_str = e.to_string();
-            if e_str.eq("invalid type: sequence, expected a map at line 1 column 11") {
-                // NOTE: The JSON is as follows: `{"changes":[]}`
-                WorkspaceEdit {
-                    changes: Some(HashMap::new()),
-                    document_changes: None,
-                    change_annotations: None,
+    // NOTE: It would be nice to use `collect_results` here, but complications introduced
+    // by the serialization issues make that more trouble than it's worth
+    if let Some(expected) = expected {
+        let actual = match test_inner::<WorkspaceEdit>(
+            &test_case,
+            Some(&vec![("NEW_NAME", format!("newName = '{new_name}'"))]),
+        ) {
+            Ok(edits) => edits.unwrap(),
+            Err(TestError::Serialization(test_id, e)) => {
+                // HACK: Comparing against the stringified error is rather hacky,
+                // but the error object's `code` field isn't accessible. In this case,
+                // we return the expected object
+                let e_str = e.to_string();
+                if e_str.eq("invalid type: sequence, expected a map at line 1 column 11") {
+                    // NOTE: The JSON is as follows: `{"changes":[]}`
+                    WorkspaceEdit {
+                        changes: Some(HashMap::new()),
+                        document_changes: None,
+                        change_annotations: None,
+                    }
+                } else if e_str.eq("invalid type: sequence, expected a map at line 1 column 21") {
+                    // NOTE: The JSON is as follows: `{"changeAnnotations":[]}`
+                    WorkspaceEdit {
+                        changes: None,
+                        document_changes: None,
+                        change_annotations: Some(HashMap::new()),
+                    }
+                } else {
+                    Err(TestError::Serialization(test_id, e))?
                 }
-            } else if e_str.eq("invalid type: sequence, expected a map at line 1 column 21") {
-                // NOTE: The JSON is as follows: `{"changeAnnotations":[]}`
-                WorkspaceEdit {
-                    changes: None,
-                    document_changes: None,
-                    change_annotations: Some(HashMap::new()),
-                }
-            } else {
-                Err(TestError::Serialization(test_id, e))?
             }
+            Err(e) => Err(e)?,
+        };
+
+        if *expected != actual {
+            Err(Box::new(RenameMismatchError {
+                test_id: test_case.test_id,
+                expected: expected.clone(),
+                actual,
+            }))?;
         }
-        Err(e) => Err(e)?,
-    };
 
-    if *expected != actual {
-        Err(Box::new(RenameMismatchError {
-            test_id: test_case.test_id,
-            expected: expected.clone(),
-            actual,
-        }))?;
+        Ok(())
+    } else {
+        let empty = test_inner::<EmptyResult>(
+            &test_case,
+            Some(&vec![("NEW_NAME", format!("newName = '{new_name}'"))]),
+        )?;
+        assert!(empty.is_none());
+        Ok(())
     }
-
-    Ok(())
 }

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -100,7 +100,7 @@ where
         .get_results_file_path()
         .map_err(|e| TestError::IO(test_case.test_id.clone(), e.to_string()))?;
     if !results_file_path.exists() {
-        Err(TestError::NoResults)?;
+        Err(TestError::NoResults(test_case.test_id.clone()))?;
     }
     let raw_results = String::from_utf8(
         fs::read(&results_file_path)

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -329,19 +329,19 @@ pub fn test_definition(
 /// server sends multiple `textDocument/publishDiagnostics` notifications before
 /// fully analyzing a source file.
 ///
+/// An `Option` is not used for `expected` because the LSP spec does not allow for
+/// nil parameters in the `textDocument/publishDiagnostics` notification.
+///
 /// # Errors
 ///
 /// Returns `TestError` if the test case is invalid, the expected results don't match,
 /// or some other failure occurs
-pub fn test_diagnostics(
-    mut test_case: TestCase,
-    expected: Option<&Vec<Diagnostic>>,
-) -> TestResult<()> {
+pub fn test_diagnostics(mut test_case: TestCase, expected: &Vec<Diagnostic>) -> TestResult<()> {
     test_case.test_type = Some(TestType::Diagnostic);
     collect_results(
         &test_case,
         None,
-        expected,
+        Some(expected),
         |expected: &Vec<Diagnostic>, actual: &Vec<Diagnostic>| {
             if expected != actual {
                 Err(DiagnosticMismatchError {

--- a/lspresso-shot/lua_templates/completion_action.lua
+++ b/lspresso-shot/lua_templates/completion_action.lua
@@ -13,7 +13,11 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global
         SET_CURSOR_POSITION,
     }, 1000)
-    if completion_result and #completion_result >= 1 and completion_result[1].result then
+
+    if not completion_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid completion result returned: ' .. vim.inspect(completion_result) .. '\n')
+    elseif completion_result and #completion_result >= 1 and completion_result[1].result then
         local results_file = io.open('RESULTS_FILE', "w")
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
@@ -37,9 +41,9 @@ local function check_progress_result()
         results_file:write(vim.json.encode(completion_result[1].result))
         results_file:close()
         ---@diagnostic enable: need-check-nil
-        vim.cmd('qa!')
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid completion result returned: ' .. vim.inspect(completion_result) .. '\n')
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
     end
+    vim.cmd('qa!')
 end

--- a/lspresso-shot/lua_templates/definition_action.lua
+++ b/lspresso-shot/lua_templates/definition_action.lua
@@ -13,7 +13,11 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global
         SET_CURSOR_POSITION,
     }, 1000)
-    if definition_results and #definition_results > 0 and definition_results[1].result then
+
+    if not definition_results then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid definition result returned: ' .. vim.inspect(definition_results) .. '\n')
+    elseif definition_results and #definition_results > 0 and definition_results[1].result then
         local results_file = io.open('RESULTS_FILE', "w")
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
@@ -49,7 +53,7 @@ local function check_progress_result()
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid definition result returned: ' .. vim.inspect(definition_results) .. '\n')
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
     end
     vim.cmd('qa!')
 end

--- a/lspresso-shot/lua_templates/diagnostic_autocmd.lua
+++ b/lspresso-shot/lua_templates/diagnostic_autocmd.lua
@@ -39,11 +39,11 @@ vim.api.nvim_create_autocmd('DiagnosticChanged', {
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(diagnostics))
             results_file:close()
-            vim.cmd('qa!')
             ---@diagnostic enable: need-check-nil
         else
             ---@diagnostic disable-next-line: undefined-global
-            report_log('No diagnostic result returned: ' .. vim.inspect(diagnostics_result) .. '\n')
+            mark_empty_file() ---@diagnostic disable-line: undefined-global
         end
+        vim.cmd('qa!')
     end,
 })

--- a/lspresso-shot/lua_templates/document_symbol.lua
+++ b/lspresso-shot/lua_templates/document_symbol.lua
@@ -12,7 +12,11 @@ local function check_progress_result()
         textDocument = vim.lsp.util.make_text_document_params(0),
         ---@diagnostic disable-next-line: undefined-global
     }, 1000)
-    if doc_sym_result and #doc_sym_result >= 1 and doc_sym_result[1].result then
+
+    if not doc_sym_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid document symbol result returned: ' .. vim.inspect(doc_sym_result) .. '\n')
+    elseif doc_sym_result and #doc_sym_result >= 1 and doc_sym_result[1].result then
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
@@ -28,10 +32,10 @@ local function check_progress_result()
         ---@diagnostic disable: need-check-nil
         results_file:write(vim.json.encode(doc_sym_result[1].result))
         results_file:close()
-        vim.cmd('qa!')
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid hover result returned: ' .. vim.inspect(doc_sym_result) .. '\n')
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
     end
+    vim.cmd('qa!')
 end

--- a/lspresso-shot/lua_templates/formatting_action.lua
+++ b/lspresso-shot/lua_templates/formatting_action.lua
@@ -33,14 +33,16 @@ JSON_OPTIONS
         ---@diagnostic disable: need-check-nil
         results_file:write('"' .. formatted .. '"')
         results_file:close()
-        vim.cmd('qa!')
         ---@diagnostic enable: need-check-nil
     else
         local formatting_result = vim.lsp.buf_request_sync(0, 'textDocument/formatting', {
             textDocument = vim.lsp.util.make_text_document_params(0),
             options = format_opts
         }, 1000)
-        if formatting_result and #formatting_result >= 1 and formatting_result[1].result then
+        if not formatting_result then
+            ---@diagnostic disable-next-line: undefined-global
+            report_log('No valid formatting result returned: ' .. vim.inspect(formatting_result) .. '\n')
+        elseif formatting_result and #formatting_result >= 1 and formatting_result[1].result then
             local results_file = io.open('RESULTS_FILE', 'w')
             if not results_file then
                 report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
@@ -50,11 +52,11 @@ JSON_OPTIONS
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(formatting_result[1].result))
             results_file:close()
-            vim.cmd('qa!')
             ---@diagnostic enable: need-check-nil
         else
             ---@diagnostic disable-next-line: undefined-global
-            report_log('No valid formatting result returned: ' .. vim.inspect(formatting_result) .. '\n')
+            mark_empty_file() ---@diagnostic disable-line: undefined-global
         end
     end
+    vim.cmd('qa!')
 end

--- a/lspresso-shot/lua_templates/helpers.lua
+++ b/lspresso-shot/lua_templates/helpers.lua
@@ -18,7 +18,21 @@ local function report_log(msg)
     end
 end
 
--- TODO: Thos could definitely use some unit tests
+--- Creates `empty` in the test case root directory
+---@diagnostic disable-next-line: unused-local, unused-function
+local function mark_empty_file()
+    local empty_file = io.open('EMPTY_PATH', "w")
+    if not empty_file then
+        report_error('Could not open empty file') ---@diagnostic disable-line: undefined-global
+        vim.cmd('qa!')
+    end
+    ---@diagnostic disable: need-check-nil
+    empty_file:write('')
+    empty_file:close()
+    ---@diagnostic enable: need-check-nil
+end
+
+-- TODO: This could definitely use some unit tests
 
 --- Extracts the relative path from a file:// URI
 ---@param uri string

--- a/lspresso-shot/lua_templates/hover_action.lua
+++ b/lspresso-shot/lua_templates/hover_action.lua
@@ -13,7 +13,11 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global
         SET_CURSOR_POSITION,
     }, 1000)
-    if hover_result and #hover_result >= 1 and hover_result[1].result and hover_result[1].result.range then
+
+    if not hover_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid hover result returned: ' .. vim.inspect(hover_result) .. '\n')
+    elseif hover_result and #hover_result >= 1 and hover_result[1].result and hover_result[1].result.range then
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
@@ -42,10 +46,10 @@ local function check_progress_result()
         ---@diagnostic disable: need-check-nil
         results_file:write(vim.json.encode(cleaned))
         results_file:close()
-        vim.cmd('qa!')
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid hover result returned: ' .. vim.inspect(hover_result) .. '\n')
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
     end
+    vim.cmd('qa!')
 end

--- a/lspresso-shot/lua_templates/references_action.lua
+++ b/lspresso-shot/lua_templates/references_action.lua
@@ -15,7 +15,10 @@ local function check_progress_result()
         SET_CONTEXT
         ---@diagnostic enable: undefined-global
     }, 1000)
-    if reference_result and #reference_result >= 1 and reference_result[1].result then
+    if not reference_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid reference result returned: ' .. vim.inspect(reference_result) .. '\n') ---@diagnostic disable-line: undefined-global
+    elseif reference_result and #reference_result >= 1 and reference_result[1].result then
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             ---@diagnostic disable-next-line: undefined-global
@@ -33,10 +36,10 @@ local function check_progress_result()
         ---@diagnostic disable: need-check-nil
         results_file:write(vim.json.encode(refs))
         results_file:close()
-        vim.cmd('qa!')
         ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid reference result returned: ' .. vim.inspect(reference_result) .. '\n') ---@diagnostic disable-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
     end
+    vim.cmd('qa!')
 end

--- a/lspresso-shot/lua_templates/rename_action.lua
+++ b/lspresso-shot/lua_templates/rename_action.lua
@@ -16,9 +16,12 @@ local function check_progress_result()
         ---@diagnostic enable: undefined-global
     }, 1000)
 
-    -- TODO: This is the logic for parsing a `WorkSpaceEdit` object. We may want
-    -- to pull this into a helper eventually for use with other test types
-    if rename_result and #rename_result >= 1 and rename_result[1].result then
+    if not rename_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid rename result returned: ' .. vim.inspect(rename_result) .. '\n') ---@diagnostic disable-line: undefined-global
+    elseif rename_result and #rename_result >= 1 and rename_result[1].result then
+        -- TODO: This is the logic for parsing a `WorkSpaceEdit` object. We may want
+        -- to pull this into a helper eventually for use with other test types
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             ---@diagnostic disable-next-line: undefined-global
@@ -38,7 +41,6 @@ local function check_progress_result()
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(rename_result[1].result))
             results_file:close()
-            vim.cmd('qa!')
             ---@diagnostic enable: need-check-nil
         elseif rename_result[1].result.changes then
             -- `WorkSpaceEdit.doucument_changes` is `Some`
@@ -59,7 +61,6 @@ local function check_progress_result()
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(result))
             results_file:close()
-            vim.cmd('qa!')
             ---@diagnostic enable: need-check-nil
         elseif rename_result[1].result.changeAnnotations then
             -- `WorkSpaceEdit.change_annotations` is `Some`
@@ -76,10 +77,11 @@ local function check_progress_result()
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(result))
             results_file:close()
-            vim.cmd('qa!')
             ---@diagnostic enable: need-check-nil
         end
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
     end
-    ---@diagnostic disable-next-line: undefined-global
-    report_log('No valid rename result returned: ' .. vim.inspect(rename_result) .. '\n') ---@diagnostic disable-line: undefined-global
+    vim.cmd('qa!')
 end

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -500,8 +500,8 @@ pub enum TestError {
     ReferencesMismatch(#[from] ReferencesMismatchError),
     #[error(transparent)]
     RenameMismatch(#[from] Box<RenameMismatchError>),
-    #[error("No results were written")]
-    NoResults,
+    #[error("Test {0}: No results were written")]
+    NoResults(String),
     #[error(transparent)]
     Setup(#[from] TestSetupError),
     #[error("Test {0}: Neovim Error\n{1}")]

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -386,7 +386,10 @@ pub fn send_diagnostic_resp(uri: &Uri, connection: &Connection) -> Result<()> {
     };
     let response_num = receive_response_num(&root_path)?;
     info!("response_num: {response_num}");
-    let publish_params = get_diagnostics_response(response_num, uri);
+    let Some(publish_params) = get_diagnostics_response(response_num, uri) else {
+        error!("Invalid response number: {response_num}");
+        return Ok(());
+    };
     info!("Sending diagnostics: {publish_params:?}");
     let result = serde_json::to_value(&publish_params).unwrap();
 

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -2,7 +2,7 @@
 mod test {
     use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
-    use crate::test_helpers::cargo_dot_toml;
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_definition,
         types::{ServerStartType, TestCase, TestFile},
@@ -21,6 +21,21 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_server_definition_empty_simple() {
+        let source_file = TestFile::new(test_server::get_source_path(), "");
+        let definition_test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = definition_test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_definition(definition_test_case, None));
+    }
+
     #[rstest]
     fn test_server_definition_simple(#[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32) {
         let resp = test_server::responses::get_definition_response(response_num).unwrap();
@@ -34,7 +49,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_definition(definition_test_case, &resp));
+        lspresso_shot!(test_definition(definition_test_case, Some(&resp)));
     }
 
     #[test]
@@ -57,7 +72,7 @@ mod test {
 
         lspresso_shot!(test_definition(
             definition_test_case,
-            &GotoDefinitionResponse::Link(vec![LocationLink {
+            Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {
                     start: Position {
@@ -89,7 +104,7 @@ mod test {
                         character: 15,
                     },
                 },
-            }])
+            }]))
         ));
     }
 }

--- a/test-suite/src/diagnostics.rs
+++ b/test-suite/src/diagnostics.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
-    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
+    use crate::test_helpers::cargo_dot_toml;
     use lspresso_shot::{
         lspresso_shot, test_diagnostics,
         types::{ServerStartType, TestCase, TestFile},
@@ -33,22 +33,6 @@ mod tests {
         }
     }
 
-    #[ignore = "https://github.com/neovim/neovim/pull/32776"]
-    #[test]
-    fn test_server_diagnostics_simple_empty() {
-        let source_file = TestFile::new(test_server::get_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
-        let test_case_root = test_case
-            .get_lspresso_dir()
-            .expect("Failed to get test case root directory");
-        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
-        send_capabiltiies(&diagnostic_capabilities_simple(), &test_case_root)
-            .expect("Failed to send capabilities");
-
-        lspresso_shot!(test_diagnostics(test_case, None));
-    }
-
     #[rstest]
     fn test_server_diagnostics_simple(#[values(0, 1, 2)] response_num: u32) {
         let uri = Uri::from_str(&test_server::get_source_path()).unwrap();
@@ -63,7 +47,7 @@ mod tests {
         send_capabiltiies(&diagnostic_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_diagnostics(test_case, Some(&resp.diagnostics)));
+        lspresso_shot!(test_diagnostics(test_case, &resp.diagnostics));
     }
 
     #[test]
@@ -100,7 +84,7 @@ mod tests {
         };
         lspresso_shot!(test_diagnostics(
             diagnostic_test_case,
-            Some(&vec![
+            &vec![
                 Diagnostic {
                     range,
                     severity: Some(DiagnosticSeverity::WARNING),
@@ -135,7 +119,7 @@ mod tests {
                     tags: None,
                     data: None,
                 }
-            ]),
+            ],
         ));
     }
 
@@ -162,7 +146,7 @@ mod tests {
         );
         lspresso_shot!(test_diagnostics(
             diagnostic_test_case,
-            Some(&vec![Diagnostic {
+            &vec![Diagnostic {
                 range: Range {
                     start: Position {
                         line: 1,
@@ -184,7 +168,7 @@ mod tests {
                 related_information: None,
                 tags: None,
                 data: Some(serde_json::Value::Object(data_map)),
-            }]),
+            }],
         ));
     }
 }

--- a/test-suite/src/document_symbol.rs
+++ b/test-suite/src/document_symbol.rs
@@ -2,7 +2,7 @@
 mod test {
     use std::{num::NonZeroU32, time::Duration};
 
-    use crate::test_helpers::cargo_dot_toml;
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_document_symbol,
         types::{ServerStartType, TestCase, TestFile},
@@ -22,6 +22,20 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_server_document_symbol_simple_empty() {
+        let source_file = TestFile::new(test_server::get_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&document_symbol_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_document_symbol(test_case, None));
+    }
+
     #[rstest]
     fn test_server_document_symbol_simple(#[values(0, 1, 2, 3)] response_num: u32) {
         let syms = test_server::responses::get_document_symbol_response(response_num).unwrap();
@@ -34,7 +48,7 @@ mod test {
         send_capabiltiies(&document_symbol_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_symbol(test_case, &syms,));
+        lspresso_shot!(test_document_symbol(test_case, Some(&syms)));
     }
 
     #[test]
@@ -56,7 +70,7 @@ mod test {
         lspresso_shot!(test_document_symbol(
             doc_sym_test_case,
             #[allow(deprecated)]
-            &DocumentSymbolResponse::Nested(vec![DocumentSymbol {
+            Some(&DocumentSymbolResponse::Nested(vec![DocumentSymbol {
                 name: "main".to_string(),
                 detail: Some("fn()".to_string()),
                 kind: SymbolKind::FUNCTION,
@@ -86,7 +100,7 @@ mod test {
                     },
                     children: None,
                 }]),
-            }]),
+            }])),
         ));
     }
 }

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -2,12 +2,12 @@
 mod test {
     use std::{num::NonZeroU32, time::Duration};
 
-    use crate::test_helpers::cargo_dot_toml;
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_hover,
         types::{ServerStartType, TestCase, TestFile},
     };
-    use test_server::{send_capabiltiies, send_response_num};
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
     use lsp_types::{
         Hover, HoverContents, HoverOptions, HoverProviderCapability, MarkupContent, MarkupKind,
@@ -36,10 +36,24 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_server_hover_simple_empty() {
+        let source_file = TestFile::new(test_server::get_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_hover(test_case, None));
+    }
+
     #[rstest]
     fn test_server_hover_simple(#[values(0, 1, 2, 3, 4, 5)] response_num: u32) {
-        use test_server::get_dummy_server_path;
-
         let resp = test_server::responses::get_hover_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
@@ -52,7 +66,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_hover(test_case, resp));
+        lspresso_shot!(test_hover(test_case, Some(&resp)));
     }
 
     #[test]
@@ -65,7 +79,7 @@ mod test {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(1).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -74,7 +88,7 @@ mod test {
 
         lspresso_shot!(test_hover(
         test_case,
-        Hover {
+        Some(&Hover {
             range: Some(Range {
                 start: Position {
                     line: 1,
@@ -141,7 +155,7 @@ let local_variable = \"some\";
 println!(\"format {local_variable} arguments\");
 ```".to_string()
             })
-        }
+        })
     ));
     }
 }

--- a/test-suite/src/test_helpers.rs
+++ b/test-suite/src/test_helpers.rs
@@ -1,5 +1,7 @@
 use lspresso_shot::types::TestFile;
 
+pub const NON_RESPONSE_NUM: u32 = u32::MAX;
+
 #[must_use]
 pub fn cargo_dot_toml() -> TestFile {
     TestFile::new(


### PR DESCRIPTION
This refactor was a bit tricky, and I'm hoping I didn't get too lost in the meta-programming sauce. Every `test_*` function now takes an `Option<&T>`, rather than the result object itself. The lua code will create a marker file (`empty`) when no results are received. The Rust side then handles `results.json`/`empty` depending on what the user passed in. 

As always, some TODOs for this PR:
- [x] This is still in a pretty rough state, so some cleanup will be necessary
- [x] The lua code still needs to handle empty results.
- [x] We need to add a bunch of tests to handle these new negative cases. I'm not sure if we'll be able to get empty responses for everything from rust-analyzer (i.e. I'm pretty sure on a format request it sends an empty `Vec` rather than `None` if the file is already formatted), but we should have pretty good coverage regardless.

Future TODOs while I'm thinking about it:
- It probably makes sense to move the `Uri` cleaning code from the Lua side over to Rust.
- Use the (somewhat) newly added `escape_slash` option in `vim.json.encode` instead of manually escaping string data.
- It might make sense to split `lspresso-shot/lib.rs` into separate files for each request/test type solely for maintainability's sake.