### PR TITLE
Some more lib cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ That's it!
 ## Dependencies:
 
 Neovim must be available on your `$PATH`. See the project's [documentation][nvim-install-docs]
-for installation instructions. (TODO: Figure out what versions are compatible)
+for installation instructions. Versions at or later than 517ecb85f58ed6ac8b4d5443931612e75e7c7dc2
+are necessary.
 
 ## Examples:
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ files
 - [ ] Clean up Lua logic (I'm unfamiliar with the neovim API)
     - Add Lua unit tests? (Do we roll our own/ is there an easy framework?)
 - [x] Add CI and whatnot (Improvements to current lua workflow?)
-- [ ] Rework treatement of "empty" results. This should allow for test cases in
+- [x] Rework treatement of "empty" results. This should allow for test cases in
 which *no* results are expected to be returned. After this refactor, both the rust-analyzer
 and dummy test cases should be augmented to match.
-- [ ] For organizational purposes, we may want a separate test file for each request
+- [x] For organizational purposes, we may want a separate test file for each request
 type. We'll definitely want to add more test coverage for each method. In addition,
 as consumers run into issues, we'll add additional regression tests.
 - [ ] Provide a means to optionally specify the path to nvim. This will be necessary

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and dummy test cases should be augmented to match.
 - [x] For organizational purposes, we may want a separate test file for each request
 type. We'll definitely want to add more test coverage for each method. In addition,
 as consumers run into issues, we'll add additional regression tests.
-- [ ] Provide a means to optionally specify the path to nvim. This will be necessary
+- [x] Provide a means to optionally specify the path to nvim. This will be necessary
 if there is a version mismatch between the user's personal installation and the version
 required by the lib. Also, users may not want to add nvim to their path. Maybe an
 environmental variable could help here?

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -324,7 +324,7 @@ fn run_test(test_case: &TestCase, source_path: &Path) -> TestResult<()> {
     let _guard = RunnerGuard::new(lock, cvar); // Ensures proper decrement on exit
 
     let start = std::time::Instant::now();
-    let mut child = Command::new("nvim")
+    let mut child = Command::new(&test_case.nvim_path)
         .arg("-u")
         .arg(init_dot_lua_path)
         .arg("--noplugin")

--- a/lspresso-shot/lua_templates/completion_action.lua
+++ b/lspresso-shot/lua_templates/completion_action.lua
@@ -23,22 +23,8 @@ local function check_progress_result()
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
-        local items = nil
-        if completion_result[1].result.items then
-            -- `CompletionResponse::List`
-            items = completion_result[1].result.items
-        else
-            -- `CompletionResponse::Array`
-            items = completion_result[1].result
-        end
-        for _, item in ipairs(items) do
-            if item.documentation and item.documentation.value then
-                item.documentation.value = string.gsub(item.documentation.value, "\\\\", "\\") -- HACK: find a better way?
-            end
-        end
-        -- HACK: Does this ever return more than one??? For now, let's just grab the first
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(completion_result[1].result))
+        results_file:write(vim.json.encode(completion_result[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/lua_templates/definition_action.lua
+++ b/lspresso-shot/lua_templates/definition_action.lua
@@ -24,29 +24,6 @@ local function check_progress_result()
             vim.cmd('qa!')
         end
 
-        if definition_results[1].result.uri then
-            report_log('Received `GotoDefinitionResponse::Scalar') ---@diagnostic disable-line: undefined-global
-            report_log('Setting `result.uri` field to relative path\n') ---@diagnostic disable-line: undefined-global
-            definition_results[1].result.uri = extract_relative_path(definition_results[1].result.uri) ---@diagnostic disable-line: undefined-global
-        else
-            for _, def in ipairs(definition_results) do
-                if def.result then
-                    for _, res in ipairs(def.result) do
-                        if res.targetUri then
-                            report_log('Received `GotoDefinitionResponse::Link') ---@diagnostic disable-line: undefined-global
-                            report_log('Setting `result.targetUri` field to relative path\n') ---@diagnostic disable-line: undefined-global
-                            res.targetUri = extract_relative_path(res.targetUri) ---@diagnostic disable-line: undefined-global
-                        elseif res.uri then
-                            -- TODO: Needs a test
-                            report_log('Received `GotoDefinitionResponse::Array') ---@diagnostic disable-line: undefined-global
-                            report_log('Setting `result.uri` field to relative path\n') ---@diagnostic disable-line: undefined-global
-                            res.uri = extract_relative_path(res.uri) ---@diagnostic disable-line: undefined-global
-                        end
-                    end
-                end
-            end
-        end
-
         ---@diagnostic disable: need-check-nil
         results_file:write(vim.json.encode(definition_results[1].result, { escape_slash = true }))
         results_file:close()

--- a/lspresso-shot/lua_templates/definition_action.lua
+++ b/lspresso-shot/lua_templates/definition_action.lua
@@ -48,7 +48,7 @@ local function check_progress_result()
         end
 
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(definition_results[1].result))
+        results_file:write(vim.json.encode(definition_results[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/lua_templates/diagnostic_autocmd.lua
+++ b/lspresso-shot/lua_templates/diagnostic_autocmd.lua
@@ -17,22 +17,8 @@ vim.api.nvim_create_autocmd('DiagnosticChanged', {
             end
 
             local diagnostics = {}
-
             for _, diagnostic in pairs(diagnostics_result) do
-                report_log('Parsing diagnostic ' .. vim.inspect(diagnostic) .. '\n') ---@diagnostic disable-line: undefined-global
-                local result = diagnostic.user_data.lsp
-                if result.relatedInformation then
-                    for info_idx, info in pairs(result.relatedInformation) do
-                        if info.location.uri then
-                            report_log('Setting `location.uri` field to relative path\n') ---@diagnostic disable-line: undefined-global
-                            ---@diagnostic disable: undefined-global
-                            result.relatedInformation[info_idx].location.uri = extract_relative_path(info.location.uri)
-                            ---@diagnostic enable: undefined-global
-                        end
-                    end
-                end
-
-                table.insert(diagnostics, result)
+                table.insert(diagnostics, diagnostic.user_data.lsp)
             end
 
             ---@diagnostic disable: need-check-nil

--- a/lspresso-shot/lua_templates/diagnostic_autocmd.lua
+++ b/lspresso-shot/lua_templates/diagnostic_autocmd.lua
@@ -21,7 +21,6 @@ vim.api.nvim_create_autocmd('DiagnosticChanged', {
             for _, diagnostic in pairs(diagnostics_result) do
                 report_log('Parsing diagnostic ' .. vim.inspect(diagnostic) .. '\n') ---@diagnostic disable-line: undefined-global
                 local result = diagnostic.user_data.lsp
-                result.message = string.gsub(result.message, "\\\\", "\\") -- HACK: find a better way?
                 if result.relatedInformation then
                     for info_idx, info in pairs(result.relatedInformation) do
                         if info.location.uri then
@@ -37,7 +36,7 @@ vim.api.nvim_create_autocmd('DiagnosticChanged', {
             end
 
             ---@diagnostic disable: need-check-nil
-            results_file:write(vim.json.encode(diagnostics))
+            results_file:write(vim.json.encode(diagnostics, { escape_slash = true }))
             results_file:close()
             ---@diagnostic enable: need-check-nil
         else

--- a/lspresso-shot/lua_templates/document_symbol.lua
+++ b/lspresso-shot/lua_templates/document_symbol.lua
@@ -22,12 +22,6 @@ local function check_progress_result()
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
-        for _, sym in ipairs(doc_sym_result[1].result) do
-            if sym.location and sym.location.uri then
-                ---@diagnostic disable-next-line: undefined-global
-                sym.location.uri = extract_relative_path(sym.location.uri)
-            end
-        end
 
         ---@diagnostic disable: need-check-nil
         results_file:write(vim.json.encode(doc_sym_result[1].result, { escape_slash = true }))

--- a/lspresso-shot/lua_templates/document_symbol.lua
+++ b/lspresso-shot/lua_templates/document_symbol.lua
@@ -30,7 +30,7 @@ local function check_progress_result()
         end
 
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(doc_sym_result[1].result))
+        results_file:write(vim.json.encode(doc_sym_result[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/lua_templates/formatting_action.lua
+++ b/lspresso-shot/lua_templates/formatting_action.lua
@@ -48,9 +48,8 @@ JSON_OPTIONS
                 report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
                 vim.cmd('qa!')
             end
-            --- NOTE: Does this ever return more than one result? Just use the first for now
             ---@diagnostic disable: need-check-nil
-            results_file:write(vim.json.encode(formatting_result[1].result))
+            results_file:write(vim.json.encode(formatting_result[1].result, { escape_slash = true }))
             results_file:close()
             ---@diagnostic enable: need-check-nil
         else

--- a/lspresso-shot/lua_templates/helpers.lua
+++ b/lspresso-shot/lua_templates/helpers.lua
@@ -31,27 +31,3 @@ local function mark_empty_file()
     empty_file:close()
     ---@diagnostic enable: need-check-nil
 end
-
--- TODO: This could definitely use some unit tests
-
---- Extracts the relative path from a file:// URI
----@param uri string
----@return string
----@diagnostic disable-next-line: unused-local, unused-function
-local function extract_relative_path(uri)
-    local path = nil
-    -- TODO: Check for other URI schemes?
-    if string.sub(uri, 1, 7) == 'file://' then
-        path = vim.uri_to_fname(uri)
-    else
-        path = uri
-    end
-    -- Only strip the start if the server returns an absolute path
-    if string.sub(path, 1, string.len('PARENT_PATH')) == 'PARENT_PATH' then
-        return string.sub(path,
-            string.len('PARENT_PATH') + 1,
-            string.len(path))
-    else
-        return path
-    end
-end

--- a/lspresso-shot/lua_templates/hover_action.lua
+++ b/lspresso-shot/lua_templates/hover_action.lua
@@ -23,28 +23,8 @@ local function check_progress_result()
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
-        local cleaned = hover_result[1].result
-        if type(cleaned.contents) == "string" then
-            cleaned.contents = string.gsub(cleaned.contents, "\\\\", "\\")
-        elseif type(cleaned.contents) == "table" and type(cleaned.contents.value) == "string" then
-            -- seems like a false positive, but maybe I'm doing something wrong?
-            ---@diagnostic disable-next-line: inject-field
-            cleaned.contents.value = string.gsub(cleaned.contents.value, "\\\\", "\\")
-        elseif #cleaned.contents >= 1 then
-            -- seems like a false positive, but maybe I'm doing something wrong?
-            ---@diagnostic disable-next-line: param-type-mismatch
-            for _, val in ipairs(cleaned.contents) do
-                if type(val) == "string" then
-                    -- `HoverContents::Array(Vec<MarkedString::String>)`
-                    val = string.gsub(val, "\\\\", "\\")
-                elseif type(val.value) == "string" then
-                    -- `HoverContents::Array(Vec<MarkedString::LanguageString>)`
-                    val.value = string.gsub(val.value, "\\\\", "\\")
-                end
-            end
-        end
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(cleaned))
+        results_file:write(vim.json.encode(hover_result[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/lua_templates/references_action.lua
+++ b/lspresso-shot/lua_templates/references_action.lua
@@ -25,15 +25,9 @@ local function check_progress_result()
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
-        local refs = reference_result[1].result
-        for i, ref in ipairs(refs) do
-            ---@diagnostic disable-next-line: undefined-global
-            local relative_path = extract_relative_path(ref.uri) ---@diagnostic disable-line: undefined-global
-            refs[i].uri = relative_path
-        end
 
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(refs, { escape_slash = true }))
+        results_file:write(vim.json.encode(reference_result[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/lua_templates/references_action.lua
+++ b/lspresso-shot/lua_templates/references_action.lua
@@ -32,9 +32,8 @@ local function check_progress_result()
             refs[i].uri = relative_path
         end
 
-        --- NOTE: Does this ever return more than one result? Just use the first for now
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(refs))
+        results_file:write(vim.json.encode(refs, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/lua_templates/rename_action.lua
+++ b/lspresso-shot/lua_templates/rename_action.lua
@@ -20,62 +20,16 @@ local function check_progress_result()
         ---@diagnostic disable-next-line: undefined-global
         report_log('No valid rename result returned: ' .. vim.inspect(rename_result) .. '\n') ---@diagnostic disable-line: undefined-global
     elseif rename_result and #rename_result >= 1 and rename_result[1].result then
-        -- TODO: This is the logic for parsing a `WorkSpaceEdit` object. We may want
-        -- to pull this into a helper eventually for use with other test types
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             ---@diagnostic disable-next-line: undefined-global
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
-        if rename_result[1].result.documentChanges then
-            -- `WorkSpaceEdit.changes` is `Some`
-            local doc_changes = rename_result[1].result.documentChanges
-            for i, edit in ipairs(doc_changes) do
-                ---@diagnostic disable-next-line: undefined-global
-                local relative_path = extract_relative_path(edit.textDocument.uri) ---@diagnostic disable-line: undefined-global
-                doc_changes[i].textDocument.uri = relative_path
-            end
-
-            ---@diagnostic disable: need-check-nil
-            results_file:write(vim.json.encode(rename_result[1].result))
-            results_file:close()
-            ---@diagnostic enable: need-check-nil
-        elseif rename_result[1].result.changes then
-            -- `WorkSpaceEdit.doucument_changes` is `Some`
-            local result = rename_result[1].result
-            -- Create a copy of the HashMap table with relative paths as the keys
-            local all_edits = {}
-            for uri, text_edits in pairs(rename_result[1].result.changes) do
-                ---@diagnostic disable-next-line: undefined-global
-                local relative_path = extract_relative_path(uri) ---@diagnostic disable-line: undefined-global
-                local uri_edits = {}
-                for _, text_edit in ipairs(text_edits) do
-                    uri_edits[#uri_edits + 1] = text_edit
-                end
-                all_edits[relative_path] = uri_edits
-            end
-            result.changes = all_edits
-            ---@diagnostic disable: need-check-nil
-            results_file:write(vim.json.encode(result))
-            results_file:close()
-            ---@diagnostic enable: need-check-nil
-        elseif rename_result[1].result.changeAnnotations then
-            -- `WorkSpaceEdit.change_annotations` is `Some`
-            local result = rename_result[1].result
-            -- Create a copy of the HashMap table with relative paths as the keys
-            local all_annotations = {}
-            for uri, annotation in pairs(rename_result[1].result.changeAnnotations) do
-                ---@diagnostic disable-next-line: undefined-global
-                local relative_path = extract_relative_path(uri) ---@diagnostic disable-line: undefined-global
-                all_annotations[relative_path] = annotation
-            end
-            result.changeAnnotations = all_annotations
-            ---@diagnostic disable: need-check-nil
-            results_file:write(vim.json.encode(result, { escape_slash = true }))
-            results_file:close()
-            ---@diagnostic enable: need-check-nil
-        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(rename_result[1].result))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
     else
         ---@diagnostic disable-next-line: undefined-global
         mark_empty_file() ---@diagnostic disable-line: undefined-global

--- a/lspresso-shot/lua_templates/rename_action.lua
+++ b/lspresso-shot/lua_templates/rename_action.lua
@@ -37,7 +37,6 @@ local function check_progress_result()
                 doc_changes[i].textDocument.uri = relative_path
             end
 
-            --- NOTE: Does this ever return more than one result? Just use the first for now
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(rename_result[1].result))
             results_file:close()
@@ -57,7 +56,6 @@ local function check_progress_result()
                 all_edits[relative_path] = uri_edits
             end
             result.changes = all_edits
-            --- NOTE: Does this ever return more than one result? Just use the first for now
             ---@diagnostic disable: need-check-nil
             results_file:write(vim.json.encode(result))
             results_file:close()
@@ -73,9 +71,8 @@ local function check_progress_result()
                 all_annotations[relative_path] = annotation
             end
             result.changeAnnotations = all_annotations
-            --- NOTE: Does this ever return more than one result? Just use the first for now
             ---@diagnostic disable: need-check-nil
-            results_file:write(vim.json.encode(result))
+            results_file:write(vim.json.encode(result, { escape_slash = true }))
             results_file:close()
             ---@diagnostic enable: need-check-nil
         end

--- a/lspresso-shot/lua_templates/rename_action.lua
+++ b/lspresso-shot/lua_templates/rename_action.lua
@@ -27,7 +27,7 @@ local function check_progress_result()
             vim.cmd('qa!')
         end
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(rename_result[1].result))
+        results_file:write(vim.json.encode(rename_result[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else


### PR DESCRIPTION
- Use `vim.json.encode`'s `escape_slash` option rather than escaping slashes manually
    - This change means that users will need neovim built at or after commit 517ecb85f58ed6ac8b4d5443931612e75e7c7dc2. 
- Move the Uri cleaning code from the Lua side over to Rust. This should help reduce code duplication a bit, and significantly simplifies the lua code. If we encounter any other fields that need to be cleaned up for other response types, this can be added into the `CleanResponse` trait implementations.
- Allow the user to specify the path to the nvim executable. This is available in two ways:
    - The `nvim_path()` method on the `TestCase` struct
    - the `LSPRESSO_NVIM` environment variable, which is checked when `TestCase::new()` is called.