### PR TITLE
chore(lib): fix Result types for some TestCase member functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ To start though, let's focus on the following TODOs:
 - [x] `textDocument/publishDiagnostics`
 - [x] `textDocument/references`
 - [x] `textDocument/rename`
+- [x] `textDocument/typeDefinition`
+- [x] `textDocument/implementation`
 - [ ] Figure out what methods we want to add next.
 
 ## Gotchas

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -45,6 +45,7 @@ pub fn get_init_dot_lua(
         | TestType::DocumentSymbol
         | TestType::Formatting
         | TestType::Hover
+        | TestType::Implementation
         | TestType::References
         | TestType::Rename
         | TestType::TypeDefinition => {
@@ -113,6 +114,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::DocumentSymbol => include_str!("lua_templates/document_symbol.lua"),
         TestType::Formatting => include_str!("lua_templates/formatting_action.lua"),
         TestType::Hover => include_str!("lua_templates/hover_action.lua"),
+        TestType::Implementation => include_str!("lua_templates/implementation_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
         TestType::TypeDefinition => include_str!("lua_templates/type_definition_action.lua"),

--- a/lspresso-shot/lua_templates/implementation_action.lua
+++ b/lspresso-shot/lua_templates/implementation_action.lua
@@ -7,24 +7,24 @@ local function check_progress_result()
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end
-    report_log('Issuing hover request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
-    local hover_result = vim.lsp.buf_request_sync(0, 'textDocument/hover', {
+    report_log('Issuing implementation request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local implementation_result = vim.lsp.buf_request_sync(0, 'textDocument/implementation', {
         textDocument = vim.lsp.util.make_text_document_params(0),
         ---@diagnostic disable-next-line: undefined-global
         SET_CURSOR_POSITION,
     }, 1000)
 
-    if not hover_result then
+    if not implementation_result then
         ---@diagnostic disable-next-line: undefined-global
-        report_log('No valid hover result returned: ' .. vim.inspect(hover_result) .. '\n')
-    elseif hover_result and #hover_result >= 1 and hover_result[1].result then
+        report_log('No valid hover result returned: ' .. vim.inspect(implementation_result) .. '\n')
+    elseif implementation_result and #implementation_result >= 1 and implementation_result[1].result then
         local results_file = io.open('RESULTS_FILE', 'w')
         if not results_file then
             report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
             vim.cmd('qa!')
         end
         ---@diagnostic disable: need-check-nil
-        results_file:write(vim.json.encode(hover_result[1].result, { escape_slash = true }))
+        results_file:write(vim.json.encode(implementation_result[1].result, { escape_slash = true }))
         results_file:close()
         ---@diagnostic enable: need-check-nil
     else

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -223,7 +223,7 @@ impl TestCase {
     ///
     /// Returns `TestSetupError` if `nvim` isn't executable, the provided server
     /// isn't executable, or if an invalid test file path is found
-    pub fn validate(&self) -> Result<(), TestSetupError> {
+    pub fn validate(&self) -> TestSetupResult<()> {
         if !is_executable(&self.nvim_path) {
             Err(TestSetupError::InvalidNeovim(self.nvim_path.clone()))?;
         }
@@ -242,7 +242,7 @@ impl TestCase {
     }
 
     /// Validate the user-provided path a test case file
-    fn validate_path(&self, input_path: &Path) -> Result<(), TestSetupError> {
+    fn validate_path(&self, input_path: &Path) -> TestSetupResult<()> {
         let test_case_root = self.get_source_file_path("")?;
         let full_path = self.get_source_file_path(input_path)?;
         if full_path.to_string_lossy().is_empty()

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -10,7 +10,7 @@ use std::{
 use anstyle::{AnsiColor, Color, Style};
 // NOTE: Is re-exporting these types really necessary?
 pub use lsp_types::{
-    request::{GotoDeclarationResponse, GotoTypeDefinitionResponse},
+    request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
     CompletionItem, CompletionList, CompletionResponse, Diagnostic, DocumentSymbolResponse,
     GotoDefinitionResponse, Hover, Location, Position, TextEdit, WorkspaceEdit,
 };
@@ -37,6 +37,8 @@ pub enum TestType {
     Formatting,
     /// Test `textDocument/hover` requests
     Hover,
+    /// Test `textDocument/implementations` requests
+    Implementation,
     /// Test `textDocument/references` requests
     References,
     /// Test `textDocument/rename` requests
@@ -58,6 +60,7 @@ impl std::fmt::Display for TestType {
                 Self::DocumentSymbol => "documentSymbol",
                 Self::Formatting => "formatting",
                 Self::Hover => "hover",
+                Self::Implementation => "implementation",
                 Self::References => "references",
                 Self::Rename => "rename",
                 Self::TypeDefinition => "typeDefinition",
@@ -531,6 +534,8 @@ pub enum TestError {
     FormattingMismatch(#[from] FormattingMismatchError),
     #[error(transparent)]
     HoverMismatch(#[from] Box<HoverMismatchError>),
+    #[error(transparent)]
+    ImplementationMismatch(#[from] Box<ImplementationMismatchError>),
     #[error(transparent)]
     ReferencesMismatch(#[from] ReferencesMismatchError),
     #[error(transparent)]
@@ -1010,6 +1015,25 @@ impl std::fmt::Display for HoverMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Hover response:", self.test_id)?;
         write_fields_comparison(f, "Hover", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub struct ImplementationMismatchError {
+    pub test_id: String,
+    pub expected: GotoImplementationResponse,
+    pub actual: GotoImplementationResponse,
+}
+
+impl std::fmt::Display for ImplementationMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Implementation response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
         Ok(())
     }
 }

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use lsp_types::{
-    request::{GotoDeclarationResponse, GotoTypeDefinitionResponse},
+    request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
     ChangeAnnotation, CodeDescription, CompletionItem, CompletionItemKind,
     CompletionItemLabelDetails, CompletionList, CompletionResponse, Diagnostic,
     DiagnosticRelatedInformation, DocumentChanges, DocumentSymbol, DocumentSymbolResponse,
@@ -223,6 +223,15 @@ pub fn get_hover_response(response_num: u32) -> Option<Hover> {
         }),
         _ => None,
     }
+}
+
+/// For use with `test_implementation`.
+///
+/// Since `textDocument/definition` and `textDocument/implementation` have the same
+/// response, this just wraps `get_definition_response`.
+#[must_use]
+pub fn get_implementation_response(response_num: u32) -> Option<GotoImplementationResponse> {
+    get_definition_response(response_num)
 }
 
 /// For use with `test_diagnostics`.

--- a/test-suite/src/implementation.rs
+++ b/test-suite/src/implementation.rs
@@ -1,0 +1,123 @@
+#[cfg(test)]
+mod test {
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
+
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
+    use lspresso_shot::{
+        lspresso_shot, test_implementation,
+        types::{ServerStartType, TestCase, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{
+        GotoDefinitionResponse, ImplementationProviderCapability, LocationLink, Position, Range,
+        ServerCapabilities, Uri,
+    };
+    use rstest::rstest;
+
+    fn implementation_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_server_implementation_empty_simple() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_implementation(test_case, None));
+    }
+
+    #[rstest]
+    fn test_server_implementation_simple(#[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32) {
+        let resp = test_server::responses::get_implementation_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_implementation(test_case, Some(&resp)));
+    }
+
+    #[test]
+    fn rust_analyzer_implementation() {
+        let source_file = TestFile::new(
+            "src/main.rs",
+            "struct Foo {
+    x: i32,
+}
+
+trait Bar {
+    fn bar(&self);
+}
+
+impl Bar for Foo {
+    fn bar(&self) {}
+}
+
+pub fn main() {
+    let foo = Foo { x: 42 };
+    foo.bar();
+}",
+        );
+        let test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(5).unwrap(),
+                "rustAnalyzer/Indexing".to_string(),
+            ))
+            .cursor_pos(Some(Position::new(14, 10)))
+            .timeout(Duration::from_secs(20))
+            .other_file(cargo_dot_toml());
+
+        lspresso_shot!(test_implementation(
+            test_case,
+            Some(&GotoDefinitionResponse::Link(vec![LocationLink {
+                target_uri: Uri::from_str("src/main.rs").unwrap(),
+                origin_selection_range: Some(Range {
+                    start: Position {
+                        line: 14,
+                        character: 8,
+                    },
+                    end: Position {
+                        line: 14,
+                        character: 11,
+                    },
+                }),
+                target_range: Range {
+                    start: Position {
+                        line: 9,
+                        character: 4,
+                    },
+                    end: Position {
+                        line: 9,
+                        character: 20,
+                    },
+                },
+                target_selection_range: Range {
+                    start: Position {
+                        line: 9,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 9,
+                        character: 10,
+                    },
+                },
+            }]))
+        ));
+    }
+}

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -7,6 +7,7 @@ mod diagnostics;
 mod document_symbol;
 mod formatting;
 mod hover;
+mod implementation;
 mod references;
 mod rename;
 mod type_definition;


### PR DESCRIPTION
Slowly chipping away...

Considering breaking up `lspresso-shot/lib.rs` and `lspresso-shot/types.rs` into separate files. Each file by itself would be relatively short, but these will become pretty unwieldy as more LSP methods are added.