### PR TITLE
feat(lib): textDocument/prepareCallHierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ To start though, let's focus on the following TODOs:
 - [x] `textDocument/documentSymbol`
 - [x] `textDocument/formatting`
 - [x] `textDocument/hover`
+- [x] `textDocument/prepareCallHierarchy`
 - [x] `textDocument/publishDiagnostics`
 - [x] `textDocument/references`
 - [x] `textDocument/rename`

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -101,7 +101,7 @@ pub fn get_init_dot_lua(
 
 fn progress_threshold(start_type: &ServerStartType) -> String {
     match start_type {
-        ServerStartType::Simple => "0".to_string(),
+        ServerStartType::Simple => "1".to_string(),
         ServerStartType::Progress(threshold, _) => threshold.to_string(),
     }
 }

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -46,6 +46,7 @@ pub fn get_init_dot_lua(
         | TestType::Formatting
         | TestType::Hover
         | TestType::Implementation
+        | TestType::PrepareCallHierarchy
         | TestType::References
         | TestType::Rename
         | TestType::TypeDefinition => {
@@ -115,6 +116,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::Formatting => include_str!("lua_templates/formatting_action.lua"),
         TestType::Hover => include_str!("lua_templates/hover_action.lua"),
         TestType::Implementation => include_str!("lua_templates/implementation_action.lua"),
+        TestType::PrepareCallHierarchy => include_str!("lua_templates/prepare_call_hierarchy_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
         TestType::TypeDefinition => include_str!("lua_templates/type_definition_action.lua"),

--- a/lspresso-shot/lua_templates/completion_action.lua
+++ b/lspresso-shot/lua_templates/completion_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/declaration_action.lua
+++ b/lspresso-shot/lua_templates/declaration_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/definition_action.lua
+++ b/lspresso-shot/lua_templates/definition_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/diagnostic_autocmd.lua
+++ b/lspresso-shot/lua_templates/diagnostic_autocmd.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 vim.api.nvim_create_autocmd('DiagnosticChanged', {
     callback = function(_)
         progress_count = progress_count + 1
-        if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
             report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
             return
         end

--- a/lspresso-shot/lua_templates/document_symbol.lua
+++ b/lspresso-shot/lua_templates/document_symbol.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/formatting_action.lua
+++ b/lspresso-shot/lua_templates/formatting_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/hover_action.lua
+++ b/lspresso-shot/lua_templates/hover_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/implementation_action.lua
+++ b/lspresso-shot/lua_templates/implementation_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/prepare_call_hierarchy_action.lua
+++ b/lspresso-shot/lua_templates/prepare_call_hierarchy_action.lua
@@ -1,0 +1,35 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    report_log('Issuing prepare call hierarchy request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local pch_result = vim.lsp.buf_request_sync(0, 'textDocument/prepareCallHierarchy', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        ---@diagnostic disable-next-line: undefined-global
+        SET_CURSOR_POSITION,
+    }, 1000)
+
+    if not pch_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid prepare call hierarchy result returned: ' .. vim.inspect(pch_result) .. '\n')
+    elseif pch_result and #pch_result >= 1 and pch_result[1].result then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(pch_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    vim.cmd('qa!')
+end

--- a/lspresso-shot/lua_templates/references_action.lua
+++ b/lspresso-shot/lua_templates/references_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/rename_action.lua
+++ b/lspresso-shot/lua_templates/rename_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/lua_templates/type_definition_action.lua
+++ b/lspresso-shot/lua_templates/type_definition_action.lua
@@ -3,7 +3,7 @@ local progress_count = 0 -- track how many times we've tried for the logs
 ---@diagnostic disable-next-line: unused-function, unused-local
 local function check_progress_result()
     progress_count = progress_count + 1
-    if progress_count < PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
         report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
         return
     end

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -11,8 +11,9 @@ use anstyle::{AnsiColor, Color, Style};
 // NOTE: Is re-exporting these types really necessary?
 pub use lsp_types::{
     request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
-    CompletionItem, CompletionList, CompletionResponse, Diagnostic, DocumentSymbolResponse,
-    GotoDefinitionResponse, Hover, Location, Position, TextEdit, WorkspaceEdit,
+    CallHierarchyItem, CompletionItem, CompletionList, CompletionResponse, Diagnostic,
+    DocumentSymbolResponse, GotoDefinitionResponse, Hover, Location, Position, TextEdit,
+    WorkspaceEdit,
 };
 use rand::distr::Distribution as _;
 use serde::{Deserialize, Serialize};
@@ -39,6 +40,8 @@ pub enum TestType {
     Hover,
     /// Test `textDocument/implementations` requests
     Implementation,
+    /// Test `textDocument/prepareCallHierarchy` requests
+    PrepareCallHierarchy,
     /// Test `textDocument/references` requests
     References,
     /// Test `textDocument/rename` requests
@@ -61,6 +64,7 @@ impl std::fmt::Display for TestType {
                 Self::Formatting => "formatting",
                 Self::Hover => "hover",
                 Self::Implementation => "implementation",
+                Self::PrepareCallHierarchy => "prepareCallHierarchy",
                 Self::References => "references",
                 Self::Rename => "rename",
                 Self::TypeDefinition => "typeDefinition",
@@ -536,6 +540,8 @@ pub enum TestError {
     HoverMismatch(#[from] Box<HoverMismatchError>),
     #[error(transparent)]
     ImplementationMismatch(#[from] Box<ImplementationMismatchError>),
+    #[error(transparent)]
+    PrepareCallHierarchyMismatch(#[from] PrepareCallHierachyMismatchError),
     #[error(transparent)]
     ReferencesMismatch(#[from] ReferencesMismatchError),
     #[error(transparent)]
@@ -1034,6 +1040,25 @@ impl std::fmt::Display for ImplementationMismatchError {
             self.test_id
         )?;
         write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub struct PrepareCallHierachyMismatchError {
+    pub test_id: String,
+    pub expected: Vec<CallHierarchyItem>,
+    pub actual: Vec<CallHierarchyItem>,
+}
+
+impl std::fmt::Display for PrepareCallHierachyMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Prepare Call Hierarchy response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Prepare Call Hierarchy", &self.expected, &self.actual, 0)?;
         Ok(())
     }
 }

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -491,7 +491,7 @@ pub enum ServerStartType {
 
 pub type TestSetupResult<T> = Result<T, TestSetupError>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum TestSetupError {
     #[error("Source file \"{0}\" must have an extension")]
     MissingFileExtension(String),
@@ -506,19 +506,19 @@ pub enum TestSetupError {
     #[error("Cursor position must be specified for {0} tests")]
     InvalidCursorPosition(TestType),
     #[error("{0}")]
-    IO(std::io::Error),
+    IO(String),
 }
 
 impl From<std::io::Error> for TestSetupError {
     fn from(value: std::io::Error) -> Self {
-        Self::IO(value)
+        Self::IO(value.to_string())
     }
 }
 
 pub type TestResult<T> = Result<T, TestError>;
 
 // NOTE: Certain variants' inner types are `Box`ed because they are large
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum TestError {
     #[error("Test {0}: Expected `None`, got:\n{1}")]
     ExpectedNone(String, String),
@@ -555,16 +555,16 @@ pub enum TestError {
     #[error("Test {0}: Neovim Error\n{1}")]
     Neovim(String, String),
     #[error("Test {0}: IO Error\n{1}")]
-    IO(String, std::io::Error),
+    IO(String, String),
     #[error("Test {0}: UTF8 Error\n{1}")]
-    Utf8(String, std::string::FromUtf8Error),
+    Utf8(String, String),
     #[error("Test {0}: Serialization Error\n{1}")]
-    Serialization(String, serde_json::Error),
+    Serialization(String, String),
     #[error(transparent)]
     TimeoutExceeded(TimeoutError),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub struct TimeoutError {
     pub test_id: String,
     pub timeout: Duration,
@@ -731,7 +731,7 @@ fn write_fields_comparison<T: Serialize>(
 // pain for library consumers. I'd like to experiment with the different ways we
 // can handle this, but for now we'll just allow for exact matching, and a simple
 // "contains" check.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum CompletionResult {
     /// Expect this exact set of completion items in the provided order
     Exact(CompletionResponse),
@@ -791,7 +791,7 @@ impl CompletionResult {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct CompletionMismatchError {
     pub test_id: String,
     pub expected: CompletionResult,
@@ -901,7 +901,7 @@ impl std::fmt::Display for CompletionMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct DeclarationMismatchError {
     pub test_id: String,
     pub expected: GotoDeclarationResponse,
@@ -920,7 +920,7 @@ impl std::fmt::Display for DeclarationMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct DefinitionMismatchError {
     pub test_id: String,
     pub expected: GotoDefinitionResponse,
@@ -939,7 +939,7 @@ impl std::fmt::Display for DefinitionMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub struct DiagnosticMismatchError {
     pub test_id: String,
     pub expected: Vec<Diagnostic>,
@@ -954,7 +954,7 @@ impl std::fmt::Display for DiagnosticMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct DocumentSymbolMismatchError {
     pub test_id: String,
     pub expected: DocumentSymbolResponse,
@@ -981,7 +981,7 @@ pub enum FormattingResult {
     Response(Vec<TextEdit>),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub struct FormattingMismatchError {
     pub test_id: String,
     pub expected: FormattingResult,
@@ -1010,7 +1010,7 @@ impl std::fmt::Display for FormattingMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub struct HoverMismatchError {
     pub test_id: String,
     pub expected: Hover,
@@ -1025,7 +1025,7 @@ impl std::fmt::Display for HoverMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct ImplementationMismatchError {
     pub test_id: String,
     pub expected: GotoImplementationResponse,
@@ -1044,7 +1044,7 @@ impl std::fmt::Display for ImplementationMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct PrepareCallHierachyMismatchError {
     pub test_id: String,
     pub expected: Vec<CallHierarchyItem>,
@@ -1063,7 +1063,7 @@ impl std::fmt::Display for PrepareCallHierachyMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub struct ReferencesMismatchError {
     pub test_id: String,
     pub expected: Vec<Location>,
@@ -1078,7 +1078,7 @@ impl std::fmt::Display for ReferencesMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub struct RenameMismatchError {
     pub test_id: String,
     pub expected: WorkspaceEdit,
@@ -1093,7 +1093,7 @@ impl std::fmt::Display for RenameMismatchError {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub struct TypeDefinitionMismatchError {
     pub test_id: String,
     pub expected: GotoTypeDefinitionResponse,

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use lsp_types::{
     request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
-    ChangeAnnotation, CodeDescription, CompletionItem, CompletionItemKind,
+    CallHierarchyItem, ChangeAnnotation, CodeDescription, CompletionItem, CompletionItemKind,
     CompletionItemLabelDetails, CompletionList, CompletionResponse, Diagnostic,
     DiagnosticRelatedInformation, DocumentChanges, DocumentSymbol, DocumentSymbolResponse,
     Documentation, GotoDefinitionResponse, Hover, HoverContents, LanguageString, Location,
@@ -232,6 +232,51 @@ pub fn get_hover_response(response_num: u32) -> Option<Hover> {
 #[must_use]
 pub fn get_implementation_response(response_num: u32) -> Option<GotoImplementationResponse> {
     get_definition_response(response_num)
+}
+
+/// For use with `test_prepare_call_hierarchy`.
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn get_prepare_call_hierachy_response(response_num: u32) -> Option<Vec<CallHierarchyItem>> {
+    let item1 = CallHierarchyItem {
+        name: "name1".to_string(),
+        kind: SymbolKind::FILE,
+        tags: None,
+        detail: Some("detail1".to_string()),
+        uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        selection_range: Range {
+            start: Position::new(5, 6),
+            end: Position::new(7, 8),
+        },
+        data: None,
+    };
+    let item2 = CallHierarchyItem {
+        name: "name2".to_string(),
+        kind: SymbolKind::FILE,
+        tags: None,
+        detail: Some("detail2\nmore details".to_string()),
+        uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+        range: Range {
+            start: Position::new(9, 10),
+            end: Position::new(11, 12),
+        },
+        selection_range: Range {
+            start: Position::new(13, 14),
+            end: Position::new(15, 16),
+        },
+        data: None,
+    };
+    match response_num {
+        0 => Some(vec![]),
+        1 => Some(vec![item1]),
+        2 => Some(vec![item2]),
+        3 => Some(vec![item1, item2]),
+        _ => None,
+    }
 }
 
 /// For use with `test_diagnostics`.

--- a/test-suite/src/declaration.rs
+++ b/test-suite/src/declaration.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_declaration,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -23,7 +23,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_declaration_empty_simple() {
+    fn test_server_declaration_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));
@@ -38,7 +38,40 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_declaration_simple(#[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32) {
+    fn test_server_declaration_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_declaration_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_declaration(test_case.clone(), None);
+        let mut expected_err =
+            TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
+        if response_num == 3 {
+            // HACK: Because of the deserialization issues with empty vector results,
+            // this error rendered incorrectly as `Link` rather than `Array`
+            assert_eq!(
+                expected_err,
+                TestError::ExpectedNone(test_case.test_id.clone(), "Link(\n    [],\n)".to_string())
+            );
+            expected_err =
+                TestError::ExpectedNone(test_case.test_id, "Array(\n    [],\n)".to_string());
+        }
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_declaration_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
+    ) {
         let resp = test_server::responses::get_declaration_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_definition,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -22,7 +22,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_definition_empty_simple() {
+    fn test_server_definition_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));
@@ -37,7 +37,40 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_definition_simple(#[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32) {
+    fn test_server_definition_expect_none_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_definition_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_definition(test_case.clone(), None);
+        let mut expected_err =
+            TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
+        if response_num == 3 {
+            // HACK: Because of the deserialization issues with empty vector results,
+            // this error rendered incorrectly as `Link` rather than `Array`
+            assert_eq!(
+                expected_err,
+                TestError::ExpectedNone(test_case.test_id.clone(), "Link(\n    [],\n)".to_string())
+            );
+            expected_err =
+                TestError::ExpectedNone(test_case.test_id, "Array(\n    [],\n)".to_string());
+        }
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_definition_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
+    ) {
         let resp = test_server::responses::get_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/document_symbol.rs
+++ b/test-suite/src/document_symbol.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_document_symbol,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -23,7 +23,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_document_symbol_simple_empty() {
+    fn test_server_document_symbol_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -37,7 +37,42 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_document_symbol_simple(#[values(0, 1, 2, 3)] response_num: u32) {
+    fn test_server_document_symbol_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let syms = test_server::responses::get_document_symbol_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&document_symbol_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_document_symbol(test_case.clone(), None);
+        let mut expected_err =
+            TestError::ExpectedNone(test_case.test_id.clone(), format!("{syms:#?}"));
+        if response_num == 1 {
+            // HACK: Because of the deserialization issues with empty vector results,
+            // this error rendered incorrectly as `Flat` rather than `Nested`
+            assert_eq!(
+                expected_err,
+                TestError::ExpectedNone(
+                    test_case.test_id.clone(),
+                    "Nested(\n    [],\n)".to_string()
+                )
+            );
+            expected_err =
+                TestError::ExpectedNone(test_case.test_id, "Flat(\n    [],\n)".to_string());
+        }
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_document_symbol_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
         let syms = test_server::responses::get_document_symbol_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_hover,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -37,7 +37,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_hover_simple_empty() {
+    fn test_server_hover_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));
@@ -53,7 +53,30 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_hover_simple(#[values(0, 1, 2, 3, 4, 5)] response_num: u32) {
+    fn test_server_hover_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_hover_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_hover(test_case.clone(), None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_hover_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
+    ) {
         let resp = test_server::responses::get_hover_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -37,23 +37,6 @@ mod test {
     }
 
     #[test]
-    fn test_server_hover_simple_empty_no_extension() {
-        // let source_file = TestFile::new(test_server::get_source_path(), "");
-        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
-
-        let test_case_root = test_case
-            .get_lspresso_dir()
-            .expect("Failed to get test case's root directory");
-        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
-        send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
-            .expect("Failed to send capabilities");
-
-        lspresso_shot!(test_hover(test_case, None));
-    }
-
-    #[test]
     fn test_server_hover_simple_empty() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -8,6 +8,7 @@ mod document_symbol;
 mod formatting;
 mod hover;
 mod implementation;
+mod prepare_call_hierarchy;
 mod references;
 mod rename;
 mod type_definition;

--- a/test-suite/src/prepare_call_hierarchy.rs
+++ b/test-suite/src/prepare_call_hierarchy.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_prepare_call_hierarchy,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -15,7 +15,7 @@ mod test {
     };
     use rstest::rstest;
 
-    fn pch_capabilities_simple() -> ServerCapabilities {
+    fn prepare_call_hierarchy_capabilities_simple() -> ServerCapabilities {
         ServerCapabilities {
             call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
             ..ServerCapabilities::default()
@@ -23,7 +23,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_prepare_call_hierarchy_simple_empty() {
+    fn test_server_prepare_call_hierarchy_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));
@@ -32,14 +32,19 @@ mod test {
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
         send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
-        send_capabiltiies(&pch_capabilities_simple(), &test_case_root)
-            .expect("Failed to send capabilities");
+        send_capabiltiies(
+            &prepare_call_hierarchy_capabilities_simple(),
+            &test_case_root,
+        )
+        .expect("Failed to send capabilities");
 
         lspresso_shot!(test_prepare_call_hierarchy(test_case, None));
     }
 
     #[rstest]
-    fn test_server_prepare_call_hierarchy_simple(#[values(0, 1, 2, 3)] response_num: u32) {
+    fn test_server_prepare_call_hierarchy_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
         let resp =
             test_server::responses::get_prepare_call_hierachy_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
@@ -50,8 +55,36 @@ mod test {
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
         send_response_num(response_num, &test_case_root).expect("Failed to send response num");
-        send_capabiltiies(&pch_capabilities_simple(), &test_case_root)
-            .expect("Failed to send capabilities");
+        send_capabiltiies(
+            &prepare_call_hierarchy_capabilities_simple(),
+            &test_case_root,
+        )
+        .expect("Failed to send capabilities");
+
+        let test_result = test_prepare_call_hierarchy(test_case.clone(), None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_prepare_call_hierarchy_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp =
+            test_server::responses::get_prepare_call_hierachy_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(
+            &prepare_call_hierarchy_capabilities_simple(),
+            &test_case_root,
+        )
+        .expect("Failed to send capabilities");
 
         lspresso_shot!(test_prepare_call_hierarchy(test_case, Some(&resp)));
     }

--- a/test-suite/src/references.rs
+++ b/test-suite/src/references.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_references,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -20,7 +20,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_references_simple_empty() {
+    fn test_server_references_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));
@@ -35,7 +35,25 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_references_simple(#[values(0, 1, 2, 3)] response_num: u32) {
+    fn test_server_references_simple_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
+        let refs = test_server::responses::get_references_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&references_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_references(test_case.clone(), true, None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{refs:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_references_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
         let refs = test_server::responses::get_references_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/rename.rs
+++ b/test-suite/src/rename.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_rename,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -23,7 +23,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_rename_simple_empty() {
+    fn test_server_rename_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::new(0, 0)));
@@ -38,7 +38,29 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_rename_simple(#[values(0, 1, 2, 3, 4, 5)] response_num: u32) {
+    fn test_server_rename_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
+    ) {
+        let edits = test_server::responses::get_rename_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::new(0, 0)));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_rename(test_case.clone(), "", None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{edits:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_rename_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
+    ) {
         let edits = test_server::responses::get_rename_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)

--- a/test-suite/src/type_definition.rs
+++ b/test-suite/src/type_definition.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_type_definition,
-        types::{ServerStartType, TestCase, TestFile},
+        types::{ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
@@ -23,7 +23,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_type_definition_empty_simple() {
+    fn test_server_type_definition_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));
@@ -38,7 +38,40 @@ mod test {
     }
 
     #[rstest]
-    fn test_server_type_definition_simple(#[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32) {
+    fn test_server_type_definition_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_type_definition_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_type_definition(test_case.clone(), None);
+        let mut expected_err =
+            TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
+        if response_num == 3 {
+            // HACK: Because of the deserialization issues with empty vector results,
+            // this error rendered incorrectly as `Link` rather than `Array`
+            assert_eq!(
+                expected_err,
+                TestError::ExpectedNone(test_case.test_id.clone(), "Link(\n    [],\n)".to_string())
+            );
+            expected_err =
+                TestError::ExpectedNone(test_case.test_id, "Array(\n    [],\n)".to_string());
+        }
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_type_definition_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
+    ) {
         let resp = test_server::responses::get_type_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)


### PR DESCRIPTION
This also adds a few fixes:

- Fixes a race condition with multithreaded servers
- Fixes incorrect display of the results actually received when `None` was expected. ~~(A few tests will be added to cover this shortly)~~ Done
    - Adding the test checking the error values required switching some of the error variants' inner data to `String` rather than the actual error source type. This was needed as they don't implement `PartialEq`.
- Removes a stale test, since I haven't figured out how to cover source files without extensions yet