### PR TITLE
feat(lib): callHierarchy/incomingCalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ for examples of how to use the library.
 As an eventual end goal, we'd obviously like to provide test coverage for *all* LSP methods.
 So far, we have:
 
-- [x] Sync up test server test coverage with current rust-analyzer coverage
 - [x] `textDocument/completion`
 - [x] `textDocument/declaration`
 - [x] `textDocument/definition`
@@ -98,6 +97,7 @@ So far, we have:
 - [x] `textDocument/rename`
 - [x] `textDocument/typeDefinition`
 - [x] `textDocument/implementation`
+- [x] `callHierarchy/incomingCalls`
 
 ## Gotchas/Known Issues
 

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -46,6 +46,7 @@ pub fn get_init_dot_lua(
         | TestType::Formatting
         | TestType::Hover
         | TestType::Implementation
+        | TestType::IncomingCalls
         | TestType::PrepareCallHierarchy
         | TestType::References
         | TestType::Rename
@@ -116,6 +117,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::Formatting => include_str!("lua_templates/formatting_action.lua"),
         TestType::Hover => include_str!("lua_templates/hover_action.lua"),
         TestType::Implementation => include_str!("lua_templates/implementation_action.lua"),
+        TestType::IncomingCalls => include_str!("lua_templates/incoming_calls_action.lua"),
         TestType::PrepareCallHierarchy => include_str!("lua_templates/prepare_call_hierarchy_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -3,9 +3,9 @@ pub mod types;
 
 use lsp_types::{
     request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
-    CallHierarchyItem, CompletionResponse, Diagnostic, DocumentChangeOperation, DocumentChanges,
-    DocumentSymbolResponse, FormattingOptions, GotoDefinitionResponse, Hover, Location, ResourceOp,
-    TextEdit, Uri, WorkspaceEdit,
+    CallHierarchyIncomingCall, CallHierarchyItem, CompletionResponse, Diagnostic,
+    DocumentChangeOperation, DocumentChanges, DocumentSymbolResponse, FormattingOptions,
+    GotoDefinitionResponse, Hover, Location, ResourceOp, TextEdit, Uri, WorkspaceEdit,
 };
 
 use std::{
@@ -20,7 +20,7 @@ use std::{
 use types::{
     CompletionMismatchError, CompletionResult, DeclarationMismatchError, DefinitionMismatchError,
     DiagnosticMismatchError, DocumentSymbolMismatchError, FormattingMismatchError,
-    FormattingResult, HoverMismatchError, ImplementationMismatchError,
+    FormattingResult, HoverMismatchError, ImplementationMismatchError, IncomingCallsMismatchError,
     PrepareCallHierachyMismatchError, ReferencesMismatchError, RenameMismatchError, TestCase,
     TestError, TestResult, TestSetupError, TestType, TimeoutError, TypeDefinitionMismatchError,
 };
@@ -108,6 +108,7 @@ impl Empty for Hover {}
 impl Empty for String {}
 impl Empty for Vec<CallHierarchyItem> {}
 impl Empty for Vec<Diagnostic> {}
+impl Empty for Vec<CallHierarchyIncomingCall> {}
 impl Empty for Vec<Location> {}
 impl Empty for Vec<TextEdit> {}
 impl Empty for WorkspaceEdit {}
@@ -194,6 +195,14 @@ impl CleanResponse for Vec<Diagnostic> {
                     related.location.uri = clean_uri(&related.location.uri, test_case)?;
                 }
             }
+        }
+        Ok(self)
+    }
+}
+impl CleanResponse for Vec<CallHierarchyIncomingCall> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for call in &mut self {
+            call.from.uri = clean_uri(&call.from.uri, test_case)?;
         }
         Ok(self)
     }
@@ -755,6 +764,39 @@ pub fn test_implementation(
         }
         Ok(())
     })
+}
+
+/// Tests the server's response to a 'callHierarchy/incomingCalls' request
+///
+/// # Errors
+///
+/// Returns `TestError` if the test case is invalid, the expected results don't match,
+/// or some other failure occurs
+pub fn test_incoming_calls(
+    mut test_case: TestCase,
+    call_item: &CallHierarchyItem,
+    expected: Option<&Vec<CallHierarchyIncomingCall>>,
+) -> TestResult<()> {
+    test_case.test_type = Some(TestType::IncomingCalls);
+    collect_results(
+        &test_case,
+        Some(&vec![(
+            "CALL_ITEM",
+            serde_json::to_string_pretty(call_item)
+                .map_err(|e| TestError::Serialization(test_case.test_id.clone(), e.to_string()))?,
+        )]),
+        expected,
+        |expected, actual: &Vec<CallHierarchyIncomingCall>| {
+            if expected != actual {
+                Err(IncomingCallsMismatchError {
+                    test_id: test_case.test_id.clone(),
+                    expected: expected.clone(),
+                    actual: actual.clone(),
+                })?;
+            }
+            Ok(())
+        },
+    )
 }
 
 /// Tests the server's response to a 'textDocument/prepareCallHierarchy' request

--- a/lspresso-shot/lua_templates/formatting_action.lua
+++ b/lspresso-shot/lua_templates/formatting_action.lua
@@ -9,11 +9,10 @@ local function check_progress_result()
     end
 
     -- Receive  json-encoded `FormattingOptions` from the rust side in `json_opts`
-    ---@diagnostic disable-next-line: undefined-global, lowercase-global
-    json_opts = [[
+    local json_opts = [[
 JSON_OPTIONS
     ]]
-    format_opts = vim.json.decode(json_opts) ---@diagnostic disable-line: undefined-global, lowercase-global
+    local format_opts = vim.json.decode(json_opts)
 
     report_log('Format opts: ' .. tostring(vim.inspect(format_opts)) .. '\n') ---@diagnostic disable-line: undefined-global
     report_log('Issuing formatting request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global

--- a/lspresso-shot/lua_templates/incoming_calls_action.lua
+++ b/lspresso-shot/lua_templates/incoming_calls_action.lua
@@ -1,0 +1,40 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    -- Receive  json-encoded `FormattingOptions` from the rust side in `json_opts`
+    local json_call_item = [[
+CALL_ITEM
+    ]]
+    local call_item = vim.json.decode(json_call_item)
+
+    report_log('Incoming calls item: ' .. tostring(call_item) .. '\n') ---@diagnostic disable-line: undefined-global
+    report_log('Issuing hover request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local incoming_calls_result = vim.lsp.buf_request_sync(0, 'callHierarchy/incomingCalls', {
+        item = call_item
+    }, 1000)
+
+    if not incoming_calls_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid hover result returned: ' .. vim.inspect(incoming_calls_result) .. '\n')
+    elseif incoming_calls_result and #incoming_calls_result >= 1 and incoming_calls_result[1].result then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(incoming_calls_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    vim.cmd('qa!')
+end

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -40,7 +40,7 @@ pub enum TestType {
     Hover,
     /// Test `textDocument/implementations` requests
     Implementation,
-    /// Test `textDocument/incomingCalls` requests
+    /// Test `callHierarchy/incomingCalls` requests
     IncomingCalls,
     /// Test `textDocument/prepareCallHierarchy` requests
     PrepareCallHierarchy,

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -204,15 +204,16 @@ pub fn handle_request(
     Ok(())
 }
 
+// TODO: Pull out common handler logic into a macro
+// This will get a little more complicated once we start checking capabilities
+// at runtime, but I think that should be doable with a closure parameter
+
 /// Sends response to a `textDocument/completion` request.
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn handle_completion(
     id: RequestId,
     params: &CompletionParams,
@@ -237,11 +238,8 @@ fn handle_completion(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn declaration(
     id: RequestId,
     params: &GotoDeclarationParams,
@@ -265,11 +263,8 @@ fn declaration(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn definition(id: RequestId, params: &GotoDefinitionParams, connection: &Connection) -> Result<()> {
     let uri = &params.text_document_position_params.text_document.uri;
     let Some(root_path) = get_root_test_path(uri) else {
@@ -289,11 +284,8 @@ fn definition(id: RequestId, params: &GotoDefinitionParams, connection: &Connect
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn document_symbol(
     id: RequestId,
     params: &DocumentSymbolParams,
@@ -317,11 +309,8 @@ fn document_symbol(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn formatting(
     id: RequestId,
     params: &DocumentFormattingParams,
@@ -346,11 +335,8 @@ fn formatting(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn hover(
     id: RequestId,
     params: &HoverParams,
@@ -393,11 +379,8 @@ fn hover(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn implementation(
     id: RequestId,
     params: &GotoImplementationParams,
@@ -421,11 +404,8 @@ fn implementation(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn incoming_calls(
     id: RequestId,
     params: &CallHierarchyIncomingCallsParams,
@@ -449,11 +429,8 @@ fn incoming_calls(
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn prepare_call_hierarchy(
     id: RequestId,
     params: &CallHierarchyPrepareParams,
@@ -477,11 +454,8 @@ fn prepare_call_hierarchy(
 ///
 /// # Errors
 ///
-/// Retruns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `Vec<Location>` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn references(id: RequestId, params: &ReferenceParams, connection: &Connection) -> Result<()> {
     let uri = &params.text_document_position.text_document.uri;
     let Some(root_path) = get_root_test_path(uri) else {
@@ -501,11 +475,8 @@ fn references(id: RequestId, params: &ReferenceParams, connection: &Connection) 
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn rename(id: RequestId, params: &RenameParams, connection: &Connection) -> Result<()> {
     let uri = &params.text_document_position.text_document.uri;
     let Some(root_path) = get_root_test_path(uri) else {
@@ -525,11 +496,8 @@ fn rename(id: RequestId, params: &RenameParams, connection: &Connection) -> Resu
 ///
 /// # Errors
 ///
-/// Returns `Err` if sending the response fails.
-///
-/// # Panics
-///
-/// Panics if serialization of `params` fails.
+/// Returns `Err` if receiving the response nummber from the test case or sending
+/// the response to  the server fails.
 fn type_definition(
     id: RequestId,
     params: &GotoTypeDefinitionParams,

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -2,13 +2,13 @@ use std::{collections::HashMap, str::FromStr};
 
 use lsp_types::{
     request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
-    CallHierarchyItem, ChangeAnnotation, CodeDescription, CompletionItem, CompletionItemKind,
-    CompletionItemLabelDetails, CompletionList, CompletionResponse, Diagnostic,
-    DiagnosticRelatedInformation, DocumentChanges, DocumentSymbol, DocumentSymbolResponse,
-    Documentation, GotoDefinitionResponse, Hover, HoverContents, LanguageString, Location,
-    LocationLink, MarkedString, MarkupContent, MarkupKind, Position, PublishDiagnosticsParams,
-    Range, SymbolInformation, SymbolKind, SymbolTag, TextDocumentEdit, TextEdit, Uri,
-    WorkspaceEdit,
+    CallHierarchyIncomingCall, CallHierarchyItem, ChangeAnnotation, CodeDescription,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionList,
+    CompletionResponse, Diagnostic, DiagnosticRelatedInformation, DocumentChanges, DocumentSymbol,
+    DocumentSymbolResponse, Documentation, GotoDefinitionResponse, Hover, HoverContents,
+    LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind, Position,
+    PublishDiagnosticsParams, Range, SymbolInformation, SymbolKind, SymbolTag, TextDocumentEdit,
+    TextEdit, Uri, WorkspaceEdit,
 };
 
 use crate::get_dummy_source_path;
@@ -232,6 +232,63 @@ pub fn get_hover_response(response_num: u32) -> Option<Hover> {
 #[must_use]
 pub fn get_implementation_response(response_num: u32) -> Option<GotoImplementationResponse> {
     get_definition_response(response_num)
+}
+
+/// For use with `test_incoming_calls`.
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn get_incoming_calls_response(response_num: u32) -> Option<Vec<CallHierarchyIncomingCall>> {
+    let item1 = CallHierarchyIncomingCall {
+        from: CallHierarchyItem {
+            name: "name1".to_string(),
+            kind: SymbolKind::FILE,
+            tags: None,
+            detail: Some("detail1".to_string()),
+            uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+            range: Range {
+                start: Position::new(1, 2),
+                end: Position::new(3, 4),
+            },
+            selection_range: Range {
+                start: Position::new(5, 6),
+                end: Position::new(7, 8),
+            },
+            data: None,
+        },
+        from_ranges: vec![Range {
+            start: Position::new(9, 10),
+            end: Position::new(11, 12),
+        }],
+    };
+    let item2 = CallHierarchyIncomingCall {
+        from: CallHierarchyItem {
+            name: "name2".to_string(),
+            kind: SymbolKind::FILE,
+            tags: None,
+            detail: Some("detail2".to_string()),
+            uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+            range: Range {
+                start: Position::new(1, 2),
+                end: Position::new(3, 4),
+            },
+            selection_range: Range {
+                start: Position::new(5, 6),
+                end: Position::new(7, 8),
+            },
+            data: None,
+        },
+        from_ranges: vec![Range {
+            start: Position::new(9, 10),
+            end: Position::new(11, 12),
+        }],
+    };
+    match response_num {
+        0 => Some(vec![]),
+        1 => Some(vec![item1]),
+        2 => Some(vec![item2]),
+        3 => Some(vec![item1, item2]),
+        _ => None,
+    }
 }
 
 /// For use with `test_prepare_call_hierarchy`.

--- a/test-suite/src/incoming_calls.rs
+++ b/test-suite/src/incoming_calls.rs
@@ -1,0 +1,202 @@
+#[cfg(test)]
+mod test {
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
+
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
+    use lspresso_shot::{
+        lspresso_shot, test_incoming_calls,
+        types::{ServerStartType, TestCase, TestError, TestFile},
+    };
+    use test_server::{
+        get_dummy_server_path, get_dummy_source_path,
+        responses::get_prepare_call_hierachy_response, send_capabiltiies, send_response_num,
+    };
+
+    use lsp_types::{
+        CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyServerCapability, Position,
+        Range, ServerCapabilities, SymbolKind, Uri,
+    };
+    use rstest::rstest;
+
+    fn incoming_calls_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
+            ..ServerCapabilities::default()
+        }
+    }
+
+    ///  Since since there isn't a `textDocument` field inside the `callHierarchy/incomingCalls`
+    ///  request params, we need to hack in a valid `uri` field so that the test server
+    ///  can respond properly
+    fn get_full_dummy_source_path(test_case: &TestCase) -> Uri {
+        Uri::from_str(
+            test_case
+                .get_source_file_path(get_dummy_source_path())
+                .unwrap()
+                .to_str()
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_server_incoming_calls_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&incoming_calls_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_incoming_calls(
+            test_case.clone(),
+            &CallHierarchyItem {
+                name: "these fields".to_string(),
+                kind: SymbolKind::EVENT,
+                tags: None,
+                detail: Some("don't matter".to_string()),
+                uri: get_full_dummy_source_path(&test_case),
+                range: Range::default(),
+                selection_range: Range::default(),
+                data: None
+            },
+            None
+        ));
+    }
+
+    #[rstest]
+    fn test_server_incoming_calls_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_incoming_calls_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&incoming_calls_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let mut call_item = get_prepare_call_hierachy_response(1).unwrap()[0].clone();
+        call_item.uri = get_full_dummy_source_path(&test_case);
+        let test_result = test_incoming_calls(test_case.clone(), &call_item, None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_incoming_calls_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_incoming_calls_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&incoming_calls_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let mut call_item = get_prepare_call_hierachy_response(1).unwrap()[0].clone();
+        call_item.uri = get_full_dummy_source_path(&test_case);
+        lspresso_shot!(test_incoming_calls(test_case, &call_item, Some(&resp)));
+    }
+
+    #[test]
+    fn rust_analyzer_incoming_calls() {
+        let source_file = TestFile::new(
+            "src/main.rs",
+            r#"fn foo() {}
+pub fn main() {
+    foo();
+    println!("Hello, world!");
+}"#,
+        );
+        let test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(4).unwrap(),
+                "rustAnalyzer/Indexing".to_string(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .other_file(cargo_dot_toml());
+
+        let uri = Uri::from_str(&format!(
+            "file://{}",
+            test_case
+                .get_source_file_path("src/main.rs")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+        ))
+        .unwrap();
+
+        let call_item = CallHierarchyItem {
+            name: "foo".to_string(),
+            kind: SymbolKind::FUNCTION,
+            tags: None,
+            detail: Some("fn foo()".to_string()),
+            uri,
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 11),
+            },
+            selection_range: Range {
+                start: Position::new(0, 3),
+                end: Position::new(0, 6),
+            },
+            data: None,
+        };
+
+        lspresso_shot!(test_incoming_calls(
+            test_case,
+            &call_item,
+            Some(&vec![CallHierarchyIncomingCall {
+                from: CallHierarchyItem {
+                    name: "main".to_string(),
+                    kind: SymbolKind::FUNCTION,
+                    tags: None,
+                    detail: Some("pub fn main()".to_string()),
+                    uri: Uri::from_str("src/main.rs").unwrap(),
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 4,
+                            character: 1,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 7,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 11,
+                        },
+                    },
+                    data: None,
+                },
+                from_ranges: vec![Range {
+                    start: Position {
+                        line: 2,
+                        character: 4,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 7,
+                    },
+                }]
+            }])
+        ));
+    }
+}

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -8,6 +8,7 @@ mod document_symbol;
 mod formatting;
 mod hover;
 mod implementation;
+mod incoming_calls;
 mod prepare_call_hierarchy;
 mod references;
 mod rename;


### PR DESCRIPTION
- Implements `callHierarchy/incomingCalls`
- Cleans up some of the request handling logic in the test server. I mostly just moved common functionality into a macro.
- Misc. other cleanup around the project