### PR TITLE
feat(lib): `textDocument/prepareTypeHierarchy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT"
 [workspace.dependencies]
 anstyle = "1.0.10"
 lsp-types = "0.97.0"
+# lsp-types = { path = "../lsp-types" }
 rand = "0.9.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ So far, we have:
 - [x] `textDocument/typeDefinition`
 - [x] `textDocument/implementation`
 - [x] `callHierarchy/incomingCalls`
+- [x] `callHierarchy/outgoingCalls`
+- [x] `textDocument/prepareTypeHierarchy`
+
 
 ## Gotchas/Known Issues
 

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -49,6 +49,7 @@ pub fn get_init_dot_lua(
         | TestType::IncomingCalls
         | TestType::OutgoingCalls
         | TestType::PrepareCallHierarchy
+        | TestType::PrepareTypeHierarchy
         | TestType::References
         | TestType::Rename
         | TestType::TypeDefinition => {
@@ -121,6 +122,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::IncomingCalls => include_str!("lua_templates/incoming_calls_action.lua"),
         TestType::OutgoingCalls => include_str!("lua_templates/outgoing_calls_action.lua"),
         TestType::PrepareCallHierarchy => include_str!("lua_templates/prepare_call_hierarchy_action.lua"),
+        TestType::PrepareTypeHierarchy => include_str!("lua_templates/prepare_type_hierarchy_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
         TestType::TypeDefinition => include_str!("lua_templates/type_definition_action.lua"),

--- a/lspresso-shot/lua_templates/prepare_type_hierarchy_action.lua
+++ b/lspresso-shot/lua_templates/prepare_type_hierarchy_action.lua
@@ -1,0 +1,35 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    report_log('Issuing prepare type hierarchy request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local pth_result = vim.lsp.buf_request_sync(0, 'textDocument/prepareTypeHierarchy', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        ---@diagnostic disable-next-line: undefined-global
+        SET_CURSOR_POSITION,
+    }, 1000)
+
+    if not pth_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid prepare type hierarchy result returned: ' .. vim.inspect(pth_result) .. '\n')
+    elseif pth_result and #pth_result >= 1 and pth_result[1].result then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(pth_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    vim.cmd('qa!')
+end

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -13,7 +13,7 @@ pub use lsp_types::{
     request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
     CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, CompletionItem,
     CompletionList, CompletionResponse, Diagnostic, DocumentSymbolResponse, GotoDefinitionResponse,
-    Hover, Location, Position, TextEdit, WorkspaceEdit,
+    Hover, Location, Position, TextEdit, TypeHierarchyItem, WorkspaceEdit,
 };
 use rand::distr::Distribution as _;
 use serde::{Deserialize, Serialize};
@@ -46,6 +46,8 @@ pub enum TestType {
     OutgoingCalls,
     /// Test `textDocument/prepareCallHierarchy` requests
     PrepareCallHierarchy,
+    /// Test `textDocument/prepareTypeHierarchy` requests
+    PrepareTypeHierarchy,
     /// Test `textDocument/references` requests
     References,
     /// Test `textDocument/rename` requests
@@ -71,6 +73,7 @@ impl std::fmt::Display for TestType {
                 Self::IncomingCalls => "callHierarchy/incomingCalls",
                 Self::OutgoingCalls => "callHierarchy/outgoingCalls",
                 Self::PrepareCallHierarchy => "textDocument/prepareCallHierarchy",
+                Self::PrepareTypeHierarchy => "textDocument/prepareTypeHierarchy",
                 Self::References => "textDocument/references",
                 Self::Rename => "textDocument/rename",
                 Self::TypeDefinition => "textDocument/typeDefinition",
@@ -552,6 +555,8 @@ pub enum TestError {
     OutgoingCallsMismatch(#[from] OutgoingCallsMismatchError),
     #[error(transparent)]
     PrepareCallHierarchyMismatch(#[from] PrepareCallHierachyMismatchError),
+    #[error(transparent)]
+    PrepareTypeHierarchyMismatch(#[from] PrepareTypeHierachyMismatchError),
     #[error(transparent)]
     ReferencesMismatch(#[from] ReferencesMismatchError),
     #[error(transparent)]
@@ -1107,6 +1112,25 @@ impl std::fmt::Display for PrepareCallHierachyMismatchError {
             self.test_id
         )?;
         write_fields_comparison(f, "Prepare Call Hierarchy", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct PrepareTypeHierachyMismatchError {
+    pub test_id: String,
+    pub expected: Vec<TypeHierarchyItem>,
+    pub actual: Vec<TypeHierarchyItem>,
+}
+
+impl std::fmt::Display for PrepareTypeHierachyMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Prepare Type Hierarchy response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Prepare Type Hierarchy", &self.expected, &self.actual, 0)?;
         Ok(())
     }
 }

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -8,11 +8,12 @@ use lsp_types::{
         DocumentDiagnosticRequest, DocumentSymbolRequest, Formatting, GotoDeclaration,
         GotoDeclarationParams, GotoDefinition, GotoImplementation, GotoImplementationParams,
         GotoTypeDefinition, GotoTypeDefinitionParams, HoverRequest, References, Rename,
-        Request as _,
+        Request as _, TypeHierarchyPrepare,
     },
     CallHierarchyIncomingCallsParams, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     CompletionParams, DocumentFormattingParams, DocumentSymbolParams, GotoDefinitionParams,
-    HoverParams, ReferenceParams, RenameParams, ServerCapabilities, Uri,
+    HoverParams, ReferenceParams, RenameParams, ServerCapabilities, TypeHierarchyPrepareParams,
+    Uri,
 };
 
 use crate::{
@@ -21,8 +22,9 @@ use crate::{
         get_completion_response, get_declaration_response, get_definition_response,
         get_diagnostics_response, get_document_symbol_response, get_formatting_response,
         get_hover_response, get_implementation_response, get_incoming_calls_response,
-        get_outgoing_calls_response, get_prepare_call_hierachy_response, get_references_response,
-        get_rename_response, get_type_definition_response,
+        get_outgoing_calls_response, get_prepare_call_hierachy_response,
+        get_prepare_type_hierachy_response, get_references_response, get_rename_response,
+        get_type_definition_response,
     },
 };
 
@@ -309,6 +311,17 @@ pub fn handle_request(
                 req,
                 conn,
                 |params: RenameParams| -> Uri { params.text_document_position.text_document.uri }
+            )?;
+        }
+        TypeHierarchyPrepare::METHOD => {
+            handle_request!(
+                TypeHierarchyPrepare,
+                get_prepare_type_hierachy_response,
+                req,
+                conn,
+                |params: TypeHierarchyPrepareParams| -> Uri {
+                    params.text_document_position_params.text_document.uri
+                }
             )?;
         }
         method => error!("Unimplemented request method: {method:?}\n{req:?}"),

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -8,7 +8,7 @@ use lsp_types::{
     DocumentSymbol, DocumentSymbolResponse, Documentation, GotoDefinitionResponse, Hover,
     HoverContents, LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind,
     Position, PublishDiagnosticsParams, Range, SymbolInformation, SymbolKind, SymbolTag,
-    TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+    TextDocumentEdit, TextEdit, TypeHierarchyItem, Uri, WorkspaceEdit,
 };
 
 use crate::get_dummy_source_path;
@@ -369,6 +369,51 @@ pub fn get_prepare_call_hierachy_response(response_num: u32) -> Option<Vec<CallH
         data: None,
     };
     let item2 = CallHierarchyItem {
+        name: "name2".to_string(),
+        kind: SymbolKind::FILE,
+        tags: None,
+        detail: Some("detail2\nmore details".to_string()),
+        uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+        range: Range {
+            start: Position::new(9, 10),
+            end: Position::new(11, 12),
+        },
+        selection_range: Range {
+            start: Position::new(13, 14),
+            end: Position::new(15, 16),
+        },
+        data: None,
+    };
+    match response_num {
+        0 => Some(vec![]),
+        1 => Some(vec![item1]),
+        2 => Some(vec![item2]),
+        3 => Some(vec![item1, item2]),
+        _ => None,
+    }
+}
+
+/// For use with `test_prepare_call_hierarchy`.
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn get_prepare_type_hierachy_response(response_num: u32) -> Option<Vec<TypeHierarchyItem>> {
+    let item1 = TypeHierarchyItem {
+        name: "name1".to_string(),
+        kind: SymbolKind::FILE,
+        tags: None,
+        detail: Some("detail1".to_string()),
+        uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        selection_range: Range {
+            start: Position::new(5, 6),
+            end: Position::new(7, 8),
+        },
+        data: None,
+    };
+    let item2 = TypeHierarchyItem {
         name: "name2".to_string(),
         kind: SymbolKind::FILE,
         tags: None,

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -11,6 +11,7 @@ mod implementation;
 mod incoming_calls;
 mod outgoing_calls;
 mod prepare_call_hierarchy;
+mod prepare_type_hierarchy;
 mod references;
 mod rename;
 mod type_definition;

--- a/test-suite/src/prepare_type_hierarchy.rs
+++ b/test-suite/src/prepare_type_hierarchy.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+mod test {
+    use crate::test_helpers::NON_RESPONSE_NUM;
+    use lspresso_shot::{
+        lspresso_shot, test_prepare_type_hierarchy,
+        types::{TestCase, TestError, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{OneOf, Position, ServerCapabilities};
+    use rstest::rstest;
+
+    fn prepare_type_hierarchy_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            // need update from lsp-types once https://github.com/gluon-lang/lsp-types/pull/298 is
+            // merged
+            type_hierarchy_provider: Some(OneOf::Left(true)),
+            ..ServerCapabilities::default()
+        }
+    }
+
+    #[test]
+    fn test_server_prepare_type_hierarchy_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(
+            &prepare_type_hierarchy_capabilities_simple(),
+            &test_case_root,
+        )
+        .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_prepare_type_hierarchy(test_case, None));
+    }
+
+    #[rstest]
+    fn test_server_prepare_type_hierarchy_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp =
+            test_server::responses::get_prepare_type_hierachy_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(
+            &prepare_type_hierarchy_capabilities_simple(),
+            &test_case_root,
+        )
+        .expect("Failed to send capabilities");
+
+        let test_result = test_prepare_type_hierarchy(test_case.clone(), None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_prepare_type_hierarchy_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp =
+            test_server::responses::get_prepare_type_hierachy_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(
+            &prepare_type_hierarchy_capabilities_simple(),
+            &test_case_root,
+        )
+        .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_prepare_type_hierarchy(test_case, Some(&resp)));
+    }
+
+    // NOTE: rust-analyzer doesn't support `textDocument/prepareTypeHierarchy` requests
+}


### PR DESCRIPTION
The `lsp-types` crate doesn't support `type_hierarchy_provider` in its `ServerCapabilities` type. Until https://github.com/gluon-lang/lsp-types/pull/298 is merged, we can't properly test this feature.