### PR TITLE
feat(lib): `textDocument/codeLens`

### DIFF
--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -39,7 +39,8 @@ pub fn get_init_dot_lua(
     );
     // This is how we actually invoke the action to be tested
     match test_type {
-        TestType::Completion
+        TestType::CodeLens
+        | TestType::Completion
         | TestType::Declaration
         | TestType::Definition
         | TestType::DocumentHighlight
@@ -88,6 +89,7 @@ pub fn get_init_dot_lua(
         .replace("EMPTY_PATH", empty_path.to_str().unwrap())
         .replace("FILE_EXTENSION", source_extension)
         .replace("SET_CURSOR_POSITION", &set_cursor_position)
+        .replace("COMMANDS", "") // clear out commands placeholder if they weren't set by `custom_replacements`
         .replace(
             "PROGRESS_THRESHOLD",
             &progress_threshold(&test_case.start_type),
@@ -113,6 +115,7 @@ fn progress_threshold(start_type: &ServerStartType) -> String {
 
 fn get_attach_action(test_type: TestType) -> String {
     match test_type {
+        TestType::CodeLens => include_str!("lua_templates/code_lens_action.lua"),
         TestType::Completion => include_str!("lua_templates/completion_action.lua"),
         TestType::Declaration => include_str!("lua_templates/declaration_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),

--- a/lspresso-shot/lua_templates/attach.lua
+++ b/lspresso-shot/lua_templates/attach.lua
@@ -16,6 +16,7 @@ vim.api.nvim_create_autocmd('FileType', {
             cmd = { 'EXECUTABLE_PATH' },
             root_dir = 'ROOT_PATH/src',
             settings = {},
+            capabilities = capabilities, ---@diagnostic disable-line: undefined-global
             on_attach = function(client, _) ---@diagnostic disable-line: unused-local
                 ---@diagnostic disable-next-line: undefined-global, exp-in-action
                 LSP_ACTION

--- a/lspresso-shot/lua_templates/code_lens_action.lua
+++ b/lspresso-shot/lua_templates/code_lens_action.lua
@@ -1,0 +1,33 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    report_log('Issuing code lens request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local code_lens_result = vim.lsp.buf_request_sync(0, 'textDocument/codeLens', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+    }, 1000)
+
+    if not code_lens_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid code lens result returned: ' .. vim.inspect(code_lens_result) .. '\n')
+    elseif code_lens_result and #code_lens_result >= 1 and code_lens_result[1].result then
+        local results_file = io.open('RESULTS_FILE', "w")
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(code_lens_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    vim.cmd('qa!')
+end

--- a/lspresso-shot/lua_templates/helpers.lua
+++ b/lspresso-shot/lua_templates/helpers.lua
@@ -31,3 +31,13 @@ local function mark_empty_file()
     empty_file:close()
     ---@diagnostic enable: need-check-nil
 end
+
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.experimental = {
+    commands = {
+        commands = {
+            ---@diagnostic disable-next-line: undefined-global
+            COMMANDS
+        },
+    },
+}

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -4,24 +4,24 @@ use lsp_server::{Connection, Message, Notification, Request, RequestId, Response
 use lsp_types::{
     notification::{DidOpenTextDocument, Notification as _, PublishDiagnostics},
     request::{
-        CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare, Completion,
-        DocumentDiagnosticRequest, DocumentHighlightRequest, DocumentLinkRequest,
-        DocumentLinkResolve, DocumentSymbolRequest, Formatting, GotoDeclaration,
-        GotoDeclarationParams, GotoDefinition, GotoImplementation, GotoImplementationParams,
-        GotoTypeDefinition, GotoTypeDefinitionParams, HoverRequest, References, Rename,
-        Request as _,
+        CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
+        CodeLensRequest, Completion, DocumentDiagnosticRequest, DocumentHighlightRequest,
+        DocumentLinkRequest, DocumentLinkResolve, DocumentSymbolRequest, Formatting,
+        GotoDeclaration, GotoDeclarationParams, GotoDefinition, GotoImplementation,
+        GotoImplementationParams, GotoTypeDefinition, GotoTypeDefinitionParams, HoverRequest,
+        References, Rename, Request as _,
     },
     CallHierarchyIncomingCallsParams, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
-    CompletionParams, DocumentFormattingParams, DocumentHighlightParams, DocumentLink,
-    DocumentLinkParams, DocumentSymbolParams, GotoDefinitionParams, HoverParams, ReferenceParams,
-    RenameParams, ServerCapabilities, Uri,
+    CodeLensParams, CompletionParams, DocumentFormattingParams, DocumentHighlightParams,
+    DocumentLink, DocumentLinkParams, DocumentSymbolParams, GotoDefinitionParams, HoverParams,
+    ReferenceParams, RenameParams, ServerCapabilities, Uri,
 };
 
 use crate::{
     get_root_test_path, receive_response_num,
     responses::{
-        get_completion_response, get_declaration_response, get_definition_response,
-        get_diagnostics_response, get_document_highlight_response,
+        get_code_lens_response, get_completion_response, get_declaration_response,
+        get_definition_response, get_diagnostics_response, get_document_highlight_response,
         get_document_link_resolve_response, get_document_link_response,
         get_document_symbol_response, get_formatting_response, get_hover_response,
         get_implementation_response, get_incoming_calls_response, get_outgoing_calls_response,
@@ -200,6 +200,15 @@ pub fn handle_request(
                 |params: CallHierarchyPrepareParams| -> Uri {
                     params.text_document_position_params.text_document.uri
                 }
+            )?;
+        }
+        CodeLensRequest::METHOD => {
+            handle_request!(
+                CodeLensRequest,
+                get_code_lens_response,
+                req,
+                conn,
+                |params: CodeLensParams| -> Uri { params.text_document.uri }
             )?;
         }
         Completion::METHOD => {

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, str::FromStr};
 use lsp_types::{
     request::{GotoDeclarationResponse, GotoImplementationResponse, GotoTypeDefinitionResponse},
     CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, ChangeAnnotation,
-    CodeDescription, CompletionItem, CompletionItemKind, CompletionItemLabelDetails,
+    CodeDescription, CodeLens, CompletionItem, CompletionItemKind, CompletionItemLabelDetails,
     CompletionList, CompletionResponse, Diagnostic, DiagnosticRelatedInformation, DocumentChanges,
     DocumentHighlight, DocumentHighlightKind, DocumentLink, DocumentSymbol, DocumentSymbolResponse,
     Documentation, GotoDefinitionResponse, Hover, HoverContents, LanguageString, Location,
@@ -159,6 +159,38 @@ pub fn get_document_symbol_response(response_num: u32) -> Option<DocumentSymbolR
             },
             children: Some(vec![]),
         }])),
+        _ => None,
+    }
+}
+
+/// For use with `test_code_lens`.
+#[must_use]
+pub fn get_code_lens_response(response_num: u32) -> Option<Vec<CodeLens>> {
+    let item1 = CodeLens {
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        command: None,
+        data: None,
+    };
+    let item2 = CodeLens {
+        range: Range {
+            start: Position::new(5, 6),
+            end: Position::new(7, 8),
+        },
+        command: Some(lsp_types::Command {
+            title: "title".to_string(),
+            command: "command".to_string(),
+            arguments: None,
+        }),
+        data: None,
+    };
+    match response_num {
+        0 => Some(vec![]),
+        1 => Some(vec![item1]),
+        2 => Some(vec![item2]),
+        3 => Some(vec![item1, item2]),
         _ => None,
     }
 }

--- a/test-suite/src/code_lens.rs
+++ b/test-suite/src/code_lens.rs
@@ -1,0 +1,148 @@
+#[cfg(test)]
+mod test {
+    use std::{num::NonZeroU32, time::Duration};
+
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
+    use lspresso_shot::{
+        lspresso_shot, test_code_lens,
+        types::{ServerStartType, TestCase, TestError, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{CodeLens, CodeLensOptions, Position, Range, ServerCapabilities};
+    use rstest::rstest;
+
+    fn code_lens_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            code_lens_provider: Some(CodeLensOptions {
+                resolve_provider: Some(false),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_server_definition_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&code_lens_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_code_lens(test_case, None, None, None));
+    }
+
+    #[rstest]
+    fn test_server_code_lens_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
+        let resp = test_server::responses::get_code_lens_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&code_lens_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_code_lens(test_case.clone(), None, None, None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_code_lens_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
+        let resp = test_server::responses::get_code_lens_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&code_lens_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_code_lens(test_case, None, None, Some(&resp)));
+    }
+
+    // NOTE: It's difficult to test for equality with rust-analyzer here, as part
+    // of the response contains arbitrary JSON values.
+    #[test]
+    fn rust_analyzer_code_lens() {
+        let source_file = TestFile::new(
+            "src/main.rs",
+            "pub fn main() {
+    let mut foo = 5;
+    foo = 10;
+}",
+        );
+        let test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(5).unwrap(),
+                "rustAnalyzer/Indexing".to_string(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .other_file(cargo_dot_toml());
+
+        let commands = vec![
+            "rust-analyzer.runSingle".to_string(),
+            "rust-analyzer.debugSingle".to_string(),
+            "rust-analyzer.showReferences".to_string(),
+            "rust-analyzer.gotoLocation".to_string(),
+        ];
+        let expected = vec![
+            CodeLens {
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 11,
+                    },
+                },
+                command: None,
+                data: None,
+            },
+            CodeLens {
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 7,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 11,
+                    },
+                },
+                command: None,
+                data: None,
+            },
+        ];
+        let cmp =
+            |expected: &Vec<CodeLens>, actual: &Vec<CodeLens>, _test_case: &TestCase| -> bool {
+                if expected.len() != actual.len() {
+                    return false;
+                }
+                for (exp, act) in expected.iter().zip(actual.iter()) {
+                    if exp.range != act.range {
+                        return false;
+                    }
+                }
+                true
+            };
+
+        lspresso_shot!(test_code_lens(
+            test_case,
+            Some(&commands),
+            Some(cmp),
+            Some(&expected)
+        ));
+    }
+}

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod test_helpers;
 
+mod code_lens;
 mod completion;
 mod declaration;
 mod definition;


### PR DESCRIPTION
This was a bit tricky.

In order for code actions to work, I had to make some slight modifications to the default neovim lsp client capabilities.

The other major roadblock was that the `CodeLens` object can contain arbitrary JSON data. This is problematic because we can't clean test-case specific data (internal implementation details) from it in the general case. The current workaround to this is to accept a custom comparator to the `test_code_lens` function, which will allow consumers to bypass the issue as needed. With this, I also marked `clean_uri` as public as a potential helper for consumers.

It may make sense to use this custom comparator "trick" for other tests, but auditing the current `test_*` function is a problem for another time. 😄

While working on this, I also had the idea to add some benchmarking feature to the library, which I've added to the README TODOs. We could leverage `vim.uv.hr_time()` and define analogous `bench_*` functions for all of the `test_*` functions, which could check the time to respond to a given request (either before and after the request is issued, or from the server attaching to the response time). Consumers could use this to add performance regression tests for particular hot paths, or to just get a general sense of their server's performance characteristics. 