### PR TITLE
feat(lib): `codeLens/resolve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ As an eventual end goal, we'd obviously like to provide test coverage for *all* 
 So far, we have:
 
 - [x] `callHierarchy/incomingCalls`
+- [x] `codeLens/resolve`
 - [x] `documentLink/resolve`
 - [x] `textDocument/codeLens`
 - [x] `textDocument/completion`

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -40,6 +40,7 @@ pub fn get_init_dot_lua(
     // This is how we actually invoke the action to be tested
     match test_type {
         TestType::CodeLens
+        | TestType::CodeLensResolve
         | TestType::Completion
         | TestType::Declaration
         | TestType::Definition
@@ -116,6 +117,7 @@ fn progress_threshold(start_type: &ServerStartType) -> String {
 fn get_attach_action(test_type: TestType) -> String {
     match test_type {
         TestType::CodeLens => include_str!("lua_templates/code_lens_action.lua"),
+        TestType::CodeLensResolve => include_str!("lua_templates/code_lens_resolve_action.lua"),
         TestType::Completion => include_str!("lua_templates/completion_action.lua"),
         TestType::Declaration => include_str!("lua_templates/declaration_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),

--- a/lspresso-shot/lua_templates/code_lens_resolve_action.lua
+++ b/lspresso-shot/lua_templates/code_lens_resolve_action.lua
@@ -1,0 +1,44 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+
+    -- Receive  json-encoded `CodeLens` from the rust side in `json_opts`
+    local json_code_lens = [[
+CODE_LENS
+    ]]
+    local code_lens = vim.json.decode(json_code_lens)
+
+    report_log('Code Lens: ' .. tostring(vim.inspect(code_lens)) .. '\n') ---@diagnostic disable-line: undefined-global
+    report_log('Issuing code lens resolve request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local code_lens_result = vim.lsp.buf_request_sync(0, 'codeLens/resolve', {
+        -- NOTE: Not sure why, but we have to manually destructure the data here
+        range = code_lens.range,
+        command = code_lens.command,
+        data = code_lens.data,
+    }, 1000)
+
+    if not code_lens_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid code lens resolve result returned: ' .. vim.inspect(code_lens_result) .. '\n')
+    elseif code_lens_result and #code_lens_result >= 1 and code_lens_result[1].result then
+        local results_file = io.open('RESULTS_FILE', "w")
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(code_lens_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    vim.cmd('qa!')
+end

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use anyhow::Result;
 use log::{error, info};
 use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
@@ -5,14 +7,14 @@ use lsp_types::{
     notification::{DidOpenTextDocument, Notification as _, PublishDiagnostics},
     request::{
         CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
-        CodeLensRequest, Completion, DocumentDiagnosticRequest, DocumentHighlightRequest,
-        DocumentLinkRequest, DocumentLinkResolve, DocumentSymbolRequest, Formatting,
-        GotoDeclaration, GotoDeclarationParams, GotoDefinition, GotoImplementation,
+        CodeLensRequest, CodeLensResolve, Completion, DocumentDiagnosticRequest,
+        DocumentHighlightRequest, DocumentLinkRequest, DocumentLinkResolve, DocumentSymbolRequest,
+        Formatting, GotoDeclaration, GotoDeclarationParams, GotoDefinition, GotoImplementation,
         GotoImplementationParams, GotoTypeDefinition, GotoTypeDefinitionParams, HoverRequest,
         References, Rename, Request as _,
     },
     CallHierarchyIncomingCallsParams, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
-    CodeLensParams, CompletionParams, DocumentFormattingParams, DocumentHighlightParams,
+    CodeLens, CodeLensParams, CompletionParams, DocumentFormattingParams, DocumentHighlightParams,
     DocumentLink, DocumentLinkParams, DocumentSymbolParams, GotoDefinitionParams, HoverParams,
     ReferenceParams, RenameParams, ServerCapabilities, Uri,
 };
@@ -20,13 +22,13 @@ use lsp_types::{
 use crate::{
     get_root_test_path, receive_response_num,
     responses::{
-        get_code_lens_response, get_completion_response, get_declaration_response,
-        get_definition_response, get_diagnostics_response, get_document_highlight_response,
-        get_document_link_resolve_response, get_document_link_response,
-        get_document_symbol_response, get_formatting_response, get_hover_response,
-        get_implementation_response, get_incoming_calls_response, get_outgoing_calls_response,
-        get_prepare_call_hierachy_response, get_references_response, get_rename_response,
-        get_type_definition_response,
+        get_code_lens_resolve_response, get_code_lens_response, get_completion_response,
+        get_declaration_response, get_definition_response, get_diagnostics_response,
+        get_document_highlight_response, get_document_link_resolve_response,
+        get_document_link_response, get_document_symbol_response, get_formatting_response,
+        get_hover_response, get_implementation_response, get_incoming_calls_response,
+        get_outgoing_calls_response, get_prepare_call_hierachy_response, get_references_response,
+        get_rename_response, get_type_definition_response,
     },
 };
 
@@ -209,6 +211,19 @@ pub fn handle_request(
                 req,
                 conn,
                 |params: CodeLensParams| -> Uri { params.text_document.uri }
+            )?;
+        }
+        CodeLensResolve::METHOD => {
+            handle_request!(
+                CodeLensResolve,
+                get_code_lens_resolve_response,
+                req,
+                conn,
+                |params: CodeLens| -> Uri {
+                    let data = params.data.unwrap();
+                    let raw_uri = data.get("uri").unwrap().as_str().unwrap();
+                    Uri::from_str(raw_uri).unwrap()
+                }
             )?;
         }
         Completion::METHOD => {

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -195,6 +195,36 @@ pub fn get_code_lens_response(response_num: u32) -> Option<Vec<CodeLens>> {
     }
 }
 
+/// For use with `test_code_lens_resolve`.
+#[must_use]
+pub fn get_code_lens_resolve_response(response_num: u32) -> Option<CodeLens> {
+    let item1 = CodeLens {
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        command: None,
+        data: None,
+    };
+    let item2 = CodeLens {
+        range: Range {
+            start: Position::new(5, 6),
+            end: Position::new(7, 8),
+        },
+        command: Some(lsp_types::Command {
+            title: "title".to_string(),
+            command: "command".to_string(),
+            arguments: None,
+        }),
+        data: None,
+    };
+    match response_num {
+        0 => Some(item1),
+        1 => Some(item2),
+        _ => None,
+    }
+}
+
 /// For use with `test_completion`.
 #[must_use]
 pub fn get_completion_response(response_num: u32) -> Option<CompletionResponse> {

--- a/test-suite/src/code_lens.rs
+++ b/test-suite/src/code_lens.rs
@@ -22,7 +22,7 @@ mod test {
     }
 
     #[test]
-    fn test_server_definition_simple_expect_none_got_none() {
+    fn test_server_code_lens_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file)
             .cursor_pos(Some(Position::default()));

--- a/test-suite/src/code_lens_resolve.rs
+++ b/test-suite/src/code_lens_resolve.rs
@@ -1,0 +1,93 @@
+#[cfg(test)]
+mod test {
+    use crate::test_helpers::NON_RESPONSE_NUM;
+    use lspresso_shot::{
+        lspresso_shot, test_code_lens_resolve,
+        types::{TestCase, TestError, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{CodeLens, CodeLensOptions, Position, Range, ServerCapabilities};
+    use rstest::rstest;
+
+    fn code_lens_resolve_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            code_lens_provider: Some(CodeLensOptions {
+                resolve_provider: Some(true),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn get_dummy_code_lens(test_case: &TestCase) -> CodeLens {
+        let uri = test_case.get_source_file_path("").unwrap();
+        CodeLens {
+            range: Range::default(),
+            command: None,
+            data: Some(serde_json::json!({ "uri": &uri })),
+        }
+    }
+
+    #[test]
+    fn test_server_code_lens_resolve_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&code_lens_resolve_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let code_lens = get_dummy_code_lens(&test_case);
+
+        lspresso_shot!(test_code_lens_resolve(
+            test_case, None, &code_lens, None, None
+        ));
+    }
+
+    #[rstest]
+    fn test_server_code_lens_resolve_expect_none_got_some(#[values(0, 1)] response_num: u32) {
+        let resp = test_server::responses::get_code_lens_resolve_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&code_lens_resolve_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let code_lens = get_dummy_code_lens(&test_case);
+
+        let test_result = test_code_lens_resolve(test_case.clone(), None, &code_lens, None, None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_code_lens_simple_expect_some_got_some(#[values(0, 1)] response_num: u32) {
+        let resp = test_server::responses::get_code_lens_resolve_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&code_lens_resolve_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let code_lens = get_dummy_code_lens(&test_case);
+
+        lspresso_shot!(test_code_lens_resolve(
+            test_case,
+            None,
+            &code_lens,
+            None,
+            Some(&resp)
+        ));
+    }
+
+    // NOTE: It's difficult to test `codeLens/resolve` requests with rust-analyzer, as its
+    // responses contain JSON data that are speciic to the ephemeral test directory
+}

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod test_helpers;
 
 mod code_lens;
+mod code_lens_resolve;
 mod completion;
 mod declaration;
 mod definition;


### PR DESCRIPTION
I wasn't able to figure out a good way to add a rust-analyzer test here, due to the same difficulties in adding `textDocument/codeLens`.