### PR TITLE
feat(lib): textDocument/selectionRange

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ So far, we have:
 - [x] `textDocument/publishDiagnostics`
 - [x] `textDocument/references`
 - [x] `textDocument/rename`
+- [x] `textDocument/selectionRange`
 - [x] `textDocument/typeDefinition`
 
 ## Gotchas/Known Issues

--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ for examples of how to use the library.
       logic out and do some string interpolation instead of duplicating it a ton.
 - [ ] Clean up Lua logic (I'm unfamiliar with the neovim API)
     - Add Lua unit tests? (Do we roll our own/ is there an easy framework?)
-- [ ] It may make sense to require a cursor position argument explicitly in the the
-      `test_*` functions, rather than accepting it implicitly in the `TestCase` struct and
-      returning an error if its missing when required. Functionally this would operate the
-      same either way, but it would make things clearer to library consumers.
 - [ ] Utilize `vim.uv.hr_time()` to provide a benchmarking utility
     - This could provide two (more?) means of measurement. One would simply test the time
     between issuing the request and receiving a response. The other would measure the time

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -74,12 +74,6 @@ pub fn get_init_dot_lua(
         }
     }
 
-    let set_cursor_position = test_case.cursor_pos.map_or_else(String::new, |cursor_pos| {
-        format!(
-            "position = {{ line = {}, character = {} }}",
-            cursor_pos.line, cursor_pos.character
-        )
-    });
     let final_init = raw_init
         .replace("RESULTS_FILE", results_file_path.to_str().unwrap())
         .replace(
@@ -91,7 +85,6 @@ pub fn get_init_dot_lua(
         .replace("LOG_PATH", log_path.to_str().unwrap())
         .replace("EMPTY_PATH", empty_path.to_str().unwrap())
         .replace("FILE_EXTENSION", source_extension)
-        .replace("SET_CURSOR_POSITION", &set_cursor_position)
         .replace("COMMANDS", "") // clear out commands placeholder if they weren't set by `custom_replacements`
         .replace(
             "PROGRESS_THRESHOLD",

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -57,6 +57,7 @@ pub fn get_init_dot_lua(
         | TestType::PrepareCallHierarchy
         | TestType::References
         | TestType::Rename
+        | TestType::SelectionRange
         | TestType::TypeDefinition => {
             raw_init = raw_init.replace("LSP_ACTION", &invoke_lsp_action(&test_case.start_type));
         }
@@ -136,6 +137,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::PrepareCallHierarchy => include_str!("lua_templates/prepare_call_hierarchy_action.lua"),
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
+        TestType::SelectionRange => include_str!("lua_templates/selection_range_action.lua"),
         TestType::TypeDefinition => include_str!("lua_templates/type_definition_action.lua"),
     }
     .to_string()

--- a/lspresso-shot/lua_templates/selection_range_action.lua
+++ b/lspresso-shot/lua_templates/selection_range_action.lua
@@ -1,0 +1,43 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+
+    -- Receive  json-encoded `Vec<Position>` from the rust side in `json_positions`
+    local json_positions = [[
+POSITIONS
+    ]]
+    local positions = vim.json.decode(json_positions)
+    report_log('Positions: ' .. vim.inspect(positions) .. '\n') ---@diagnostic disable-line: undefined-global
+    report_log('Issuing selection range request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local selection_range_results = vim.lsp.buf_request_sync(0, "textDocument/selectionRange", {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        ---@diagnostic disable-next-line: undefined-global
+        positions = positions
+    }, 1000)
+
+    if not selection_range_results then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid selection range result returned: ' .. vim.inspect(selection_range_results) .. '\n')
+    elseif selection_range_results and #selection_range_results > 0 and selection_range_results[1].result then
+        local results_file = io.open('RESULTS_FILE', "w")
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            vim.cmd('qa!')
+        end
+
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(selection_range_results[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    vim.cmd('qa!')
+end

--- a/lspresso-shot/types.rs
+++ b/lspresso-shot/types.rs
@@ -532,8 +532,6 @@ pub enum TestSetupError {
     InvalidFileExtension(String),
     #[error("Source file path \"{0}\" is invalid")]
     InvalidFilePath(String),
-    #[error("Cursor position must be specified for {0} tests")]
-    InvalidCursorPosition(TestType),
     #[error("{0}")]
     IO(String),
 }

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -11,12 +11,13 @@ use lsp_types::{
         DocumentHighlightRequest, DocumentLinkRequest, DocumentLinkResolve, DocumentSymbolRequest,
         FoldingRangeRequest, Formatting, GotoDeclaration, GotoDeclarationParams, GotoDefinition,
         GotoImplementation, GotoImplementationParams, GotoTypeDefinition, GotoTypeDefinitionParams,
-        HoverRequest, References, Rename, Request as _,
+        HoverRequest, References, Rename, Request as _, SelectionRangeRequest,
     },
     CallHierarchyIncomingCallsParams, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     CodeLens, CodeLensParams, CompletionParams, DocumentFormattingParams, DocumentHighlightParams,
     DocumentLink, DocumentLinkParams, DocumentSymbolParams, FoldingRangeParams,
-    GotoDefinitionParams, HoverParams, ReferenceParams, RenameParams, ServerCapabilities, Uri,
+    GotoDefinitionParams, HoverParams, ReferenceParams, RenameParams, SelectionRangeParams,
+    ServerCapabilities, Uri,
 };
 
 use crate::{
@@ -29,7 +30,7 @@ use crate::{
         get_formatting_response, get_hover_response, get_implementation_response,
         get_incoming_calls_response, get_outgoing_calls_response,
         get_prepare_call_hierachy_response, get_references_response, get_rename_response,
-        get_type_definition_response,
+        get_selection_range_response, get_type_definition_response,
     },
 };
 
@@ -376,6 +377,15 @@ pub fn handle_request(
                 req,
                 conn,
                 |params: RenameParams| -> Uri { params.text_document_position.text_document.uri }
+            )?;
+        }
+        SelectionRangeRequest::METHOD => {
+            handle_request!(
+                SelectionRangeRequest,
+                get_selection_range_response,
+                req,
+                conn,
+                |params: SelectionRangeParams| -> Uri { params.text_document.uri }
             )?;
         }
         method => error!("Unimplemented request method: {method:?}\n{req:?}"),

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -8,8 +8,8 @@ use lsp_types::{
     DocumentHighlight, DocumentHighlightKind, DocumentLink, DocumentSymbol, DocumentSymbolResponse,
     Documentation, FoldingRange, FoldingRangeKind, GotoDefinitionResponse, Hover, HoverContents,
     LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind, Position,
-    PublishDiagnosticsParams, Range, SymbolInformation, SymbolKind, SymbolTag, TextDocumentEdit,
-    TextEdit, Uri, WorkspaceEdit,
+    PublishDiagnosticsParams, Range, SelectionRange, SymbolInformation, SymbolKind, SymbolTag,
+    TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
 };
 
 use crate::get_dummy_source_path;
@@ -787,6 +787,32 @@ pub fn get_references_response(response_num: u32) -> Option<Vec<Location>> {
                 },
             },
         ]),
+        _ => None,
+    }
+}
+
+/// For use with `test_selection_range`.
+#[must_use]
+pub fn get_selection_range_response(response_num: u32) -> Option<Vec<SelectionRange>> {
+    let item1 = SelectionRange {
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        parent: None,
+    };
+    let item2 = SelectionRange {
+        range: Range {
+            start: Position::new(5, 6),
+            end: Position::new(7, 8),
+        },
+        parent: Some(Box::new(item1.clone())),
+    };
+    match response_num {
+        0 => Some(vec![]),
+        1 => Some(vec![item1]),
+        2 => Some(vec![item2]),
+        3 => Some(vec![item1, item2]),
         _ => None,
     }
 }

--- a/test-suite/src/code_lens.rs
+++ b/test-suite/src/code_lens.rs
@@ -24,8 +24,8 @@ mod test {
     #[test]
     fn test_server_code_lens_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");

--- a/test-suite/src/code_lens_resolve.rs
+++ b/test-suite/src/code_lens_resolve.rs
@@ -7,7 +7,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{CodeLens, CodeLensOptions, Position, Range, ServerCapabilities};
+    use lsp_types::{CodeLens, CodeLensOptions, Range, ServerCapabilities};
     use rstest::rstest;
 
     fn code_lens_resolve_capabilities_simple() -> ServerCapabilities {
@@ -31,8 +31,7 @@ mod test {
     #[test]
     fn test_server_code_lens_resolve_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");

--- a/test-suite/src/completion.rs
+++ b/test-suite/src/completion.rs
@@ -37,8 +37,7 @@ mod test {
     #[test]
     fn test_server_completion_exact_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -46,7 +45,7 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_completion(test_case, None));
+        lspresso_shot!(test_completion(test_case, &Position::default(), None));
     }
 
     #[rstest]
@@ -55,8 +54,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_completion_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -64,7 +62,7 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_completion(test_case.clone(), None);
+        let test_result = test_completion(test_case.clone(), &Position::default(), None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -76,8 +74,7 @@ mod test {
         let resp = test_server::responses::get_completion_response(response_num).unwrap();
         let comp_result = CompletionResult::Exact(resp);
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -85,7 +82,11 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_completion(test_case, Some(&comp_result)));
+        lspresso_shot!(test_completion(
+            test_case,
+            &Position::default(),
+            Some(&comp_result)
+        ));
     }
 
     #[rstest]
@@ -100,8 +101,7 @@ mod test {
             }
         };
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -109,7 +109,11 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_completion(test_case, Some(&comp_result)));
+        lspresso_shot!(test_completion(
+            test_case,
+            &Position::default(),
+            Some(&comp_result)
+        ));
     }
 
     // TODO: The end user experience for debugging completions test with CompletionResult::Contains
@@ -214,9 +218,12 @@ println!("format {local_variable} arguments");
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .timeout(Duration::from_secs(20))
-            .cursor_pos(Some(Position::new(1, 9)))
             .other_file(cargo_dot_toml());
 
-        lspresso_shot!(test_completion(test_case, Some(&expected_comps)));
+        lspresso_shot!(test_completion(
+            test_case,
+            &Position::new(1, 9),
+            Some(&expected_comps)
+        ));
     }
 }

--- a/test-suite/src/declaration.rs
+++ b/test-suite/src/declaration.rs
@@ -25,8 +25,7 @@ mod test {
     #[test]
     fn test_server_declaration_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -34,7 +33,7 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_declaration(test_case, None));
+        lspresso_shot!(test_declaration(test_case, &Position::default(), None));
     }
 
     #[rstest]
@@ -43,8 +42,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_declaration_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -52,7 +50,7 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_declaration(test_case.clone(), None);
+        let test_result = test_declaration(test_case.clone(), &Position::default(), None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -74,8 +72,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_declaration_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -83,7 +80,11 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_declaration(test_case, Some(&resp)));
+        lspresso_shot!(test_declaration(
+            test_case,
+            &Position::default(),
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -100,12 +101,12 @@ mod test {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(2, 5)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_declaration(
             test_case,
+            &Position::new(2, 5),
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -24,8 +24,7 @@ mod test {
     #[test]
     fn test_server_definition_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -33,7 +32,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_definition(test_case, None));
+        lspresso_shot!(test_definition(test_case, &Position::default(), None));
     }
 
     #[rstest]
@@ -42,8 +41,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -51,7 +49,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_definition(test_case.clone(), None);
+        let test_result = test_definition(test_case.clone(), &Position::default(), None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -73,8 +71,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -82,7 +79,11 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_definition(test_case, Some(&resp)));
+        lspresso_shot!(test_definition(
+            test_case,
+            &Position::default(),
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -99,12 +100,12 @@ mod test {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(2, 5)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_definition(
             test_case,
+            &Position::new(2, 5),
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {

--- a/test-suite/src/diagnostics.rs
+++ b/test-suite/src/diagnostics.rs
@@ -38,8 +38,8 @@ mod tests {
         let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp = test_server::responses::get_diagnostics_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case root directory");

--- a/test-suite/src/document_highlight.rs
+++ b/test-suite/src/document_highlight.rs
@@ -22,8 +22,7 @@ mod test {
     #[test]
     fn test_server_document_highlight_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -32,7 +31,11 @@ mod test {
         send_capabiltiies(&document_highlight_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_highlight(test_case, None));
+        lspresso_shot!(test_document_highlight(
+            test_case,
+            &Position::default(),
+            None
+        ));
     }
 
     #[rstest]
@@ -41,8 +44,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_document_highlight_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -51,7 +53,7 @@ mod test {
         send_capabiltiies(&document_highlight_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_document_highlight(test_case.clone(), None);
+        let test_result = test_document_highlight(test_case.clone(), &Position::default(), None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -62,8 +64,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_document_highlight_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -72,7 +73,11 @@ mod test {
         send_capabiltiies(&document_highlight_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_highlight(test_case, Some(&resp)));
+        lspresso_shot!(test_document_highlight(
+            test_case,
+            &Position::default(),
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -88,12 +93,12 @@ mod test {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(1, 9)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_document_highlight(
             test_case,
+            &Position::new(1, 9),
             Some(&vec![DocumentHighlight {
                 range: Range {
                     start: Position::new(1, 8),

--- a/test-suite/src/folding_range.rs
+++ b/test-suite/src/folding_range.rs
@@ -22,8 +22,7 @@ mod test {
     #[test]
     fn test_server_folding_range_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -39,8 +39,7 @@ mod test {
     #[test]
     fn test_server_hover_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -49,7 +48,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_hover(test_case, None));
+        lspresso_shot!(test_hover(test_case, &Position::default(), None));
     }
 
     #[rstest]
@@ -58,8 +57,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_hover_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -68,7 +66,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_hover(test_case.clone(), None);
+        let test_result = test_hover(test_case.clone(), &Position::default(), None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -79,8 +77,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_hover_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -89,7 +86,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_hover(test_case, Some(&resp)));
+        lspresso_shot!(test_hover(test_case, &Position::default(), Some(&resp)));
     }
 
     #[test]
@@ -106,11 +103,11 @@ mod test {
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .timeout(Duration::from_secs(20))
-            .cursor_pos(Some(Position::new(1, 5)))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_hover(
         test_case,
+        &Position::new(1, 5),
         Some(&Hover {
             range: Some(Range {
                 start: Position {

--- a/test-suite/src/implementation.rs
+++ b/test-suite/src/implementation.rs
@@ -25,8 +25,7 @@ mod test {
     #[test]
     fn test_server_implementation_empty_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -34,7 +33,7 @@ mod test {
         send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_implementation(test_case, None));
+        lspresso_shot!(test_implementation(test_case, &Position::default(), None));
     }
 
     #[rstest]
@@ -43,8 +42,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_implementation_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -52,7 +50,7 @@ mod test {
         send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_implementation(test_case.clone(), None);
+        let test_result = test_implementation(test_case.clone(), &Position::default(), None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -74,8 +72,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_implementation_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -83,7 +80,11 @@ mod test {
         send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_implementation(test_case, Some(&resp)));
+        lspresso_shot!(test_implementation(
+            test_case,
+            &Position::default(),
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -112,12 +113,12 @@ pub fn main() {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(14, 10)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_implementation(
             test_case,
+            &Position::new(14, 10),
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -19,4 +19,5 @@ mod outgoing_calls;
 mod prepare_call_hierarchy;
 mod references;
 mod rename;
+mod selection_range;
 mod type_definition;

--- a/test-suite/src/prepare_call_hierarchy.rs
+++ b/test-suite/src/prepare_call_hierarchy.rs
@@ -25,8 +25,7 @@ mod test {
     #[test]
     fn test_server_prepare_call_hierarchy_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -38,7 +37,11 @@ mod test {
         )
         .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_prepare_call_hierarchy(test_case, None));
+        lspresso_shot!(test_prepare_call_hierarchy(
+            test_case,
+            &Position::default(),
+            None
+        ));
     }
 
     #[rstest]
@@ -48,8 +51,7 @@ mod test {
         let resp =
             test_server::responses::get_prepare_call_hierachy_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -61,7 +63,8 @@ mod test {
         )
         .expect("Failed to send capabilities");
 
-        let test_result = test_prepare_call_hierarchy(test_case.clone(), None);
+        let test_result =
+            test_prepare_call_hierarchy(test_case.clone(), &Position::default(), None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -73,8 +76,7 @@ mod test {
         let resp =
             test_server::responses::get_prepare_call_hierachy_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
         let test_case_root = test_case
             .get_lspresso_dir()
@@ -86,7 +88,11 @@ mod test {
         )
         .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_prepare_call_hierarchy(test_case, Some(&resp)));
+        lspresso_shot!(test_prepare_call_hierarchy(
+            test_case,
+            &Position::default(),
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -103,11 +109,11 @@ mod test {
                 "rustAnalyzer/Indexing".to_string(),
             ))
             .timeout(Duration::from_secs(20))
-            .cursor_pos(Some(Position::new(0, 8)))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
+            &Position::new(0, 8),
             Some(&vec![CallHierarchyItem {
                 name: "main".to_string(),
                 kind: SymbolKind::FUNCTION,

--- a/test-suite/src/references.rs
+++ b/test-suite/src/references.rs
@@ -22,8 +22,7 @@ mod test {
     #[test]
     fn test_server_references_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -31,15 +30,14 @@ mod test {
         send_capabiltiies(&references_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_references(test_case, true, None));
+        lspresso_shot!(test_references(test_case, &Position::default(), true, None));
     }
 
     #[rstest]
     fn test_server_references_simple_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
         let refs = test_server::responses::get_references_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -47,7 +45,7 @@ mod test {
         send_capabiltiies(&references_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_references(test_case.clone(), true, None);
+        let test_result = test_references(test_case.clone(), &Position::default(), true, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{refs:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -56,8 +54,7 @@ mod test {
     fn test_server_references_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
         let refs = test_server::responses::get_references_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -65,7 +62,12 @@ mod test {
         send_capabiltiies(&references_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_references(test_case, true, Some(&refs)));
+        lspresso_shot!(test_references(
+            test_case,
+            &Position::default(),
+            true,
+            Some(&refs)
+        ));
     }
 
     #[test]
@@ -81,12 +83,12 @@ mod test {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(1, 9)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_references(
             reference_test_case,
+            &Position::new(1, 9),
             true,
             Some(&vec![Location {
                 uri: Uri::from_str("src/main.rs").unwrap(),

--- a/test-suite/src/rename.rs
+++ b/test-suite/src/rename.rs
@@ -25,8 +25,7 @@ mod test {
     #[test]
     fn test_server_rename_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::new(0, 0)));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -34,7 +33,7 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_rename(test_case, "", None));
+        lspresso_shot!(test_rename(test_case, &Position::default(), "", None));
     }
 
     #[rstest]
@@ -43,8 +42,7 @@ mod test {
     ) {
         let edits = test_server::responses::get_rename_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::new(0, 0)));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -52,7 +50,7 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_rename(test_case.clone(), "", None);
+        let test_result = test_rename(test_case.clone(), &Position::default(), "", None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{edits:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -63,8 +61,7 @@ mod test {
     ) {
         let edits = test_server::responses::get_rename_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::new(0, 0)));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -72,7 +69,12 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_rename(test_case, "", Some(&edits)));
+        lspresso_shot!(test_rename(
+            test_case,
+            &Position::default(),
+            "",
+            Some(&edits)
+        ));
     }
 
     #[test]
@@ -88,12 +90,12 @@ mod test {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(1, 9)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_rename(
             rename_test_case,
+            &Position::new(1, 9),
             "bar",
             Some(&WorkspaceEdit {
                 changes: None,

--- a/test-suite/src/selection_range.rs
+++ b/test-suite/src/selection_range.rs
@@ -1,0 +1,154 @@
+#[cfg(test)]
+mod test {
+    use std::{num::NonZeroU32, time::Duration};
+
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
+    use lspresso_shot::{
+        lspresso_shot, test_selection_range,
+        types::{ServerStartType, TestCase, TestError, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{
+        Position, Range, SelectionRange, SelectionRangeProviderCapability, ServerCapabilities,
+    };
+    use rstest::rstest;
+
+    fn selection_range_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_server_selection_range_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&selection_range_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_selection_range(test_case, &Vec::new(), None));
+    }
+
+    #[rstest]
+    fn test_server_selection_range_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_selection_range_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&selection_range_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let positions = vec![Position::default()];
+
+        let test_result = test_selection_range(test_case.clone(), &positions, None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_selection_range_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let resp = test_server::responses::get_selection_range_response(response_num).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file)
+            .cursor_pos(Some(Position::default()));
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&selection_range_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let positions = vec![Position::default(); 3];
+
+        lspresso_shot!(test_selection_range(test_case, &positions, Some(&resp)));
+    }
+
+    #[test]
+    fn rust_analyzer_selection_range() {
+        let source_file = TestFile::new(
+            "src/main.rs",
+            "struct Foo {
+        x: i32,
+    }
+
+    pub fn main() {
+        let foo = Foo { x: 5 };
+    }",
+        );
+        let test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(5).unwrap(),
+                "rustAnalyzer/Indexing".to_string(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .other_file(cargo_dot_toml());
+        let positions = vec![Position::new(0, 8)];
+
+        lspresso_shot!(test_selection_range(
+            test_case,
+            &positions,
+            Some(&vec![SelectionRange {
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 8,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 8,
+                    },
+                },
+                parent: Some(Box::new(SelectionRange {
+                    range: Range {
+                        start: Position {
+                            line: 0,
+                            character: 7,
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 10,
+                        },
+                    },
+                    parent: Some(Box::new(SelectionRange {
+                        range: Range {
+                            start: Position {
+                                line: 0,
+                                character: 0,
+                            },
+                            end: Position {
+                                line: 2,
+                                character: 5,
+                            },
+                        },
+                        parent: Some(Box::new(SelectionRange {
+                            range: Range {
+                                start: Position {
+                                    line: 0,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 6,
+                                    character: 5,
+                                },
+                            },
+                            parent: None,
+                        }),),
+                    }),),
+                }),),
+            },])
+        ));
+    }
+}

--- a/test-suite/src/type_definition.rs
+++ b/test-suite/src/type_definition.rs
@@ -25,8 +25,7 @@ mod test {
     #[test]
     fn test_server_type_definition_simple_expect_none_got_none() {
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -34,7 +33,7 @@ mod test {
         send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_type_definition(test_case, None));
+        lspresso_shot!(test_type_definition(test_case, &Position::default(), None));
     }
 
     #[rstest]
@@ -43,8 +42,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_type_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -52,7 +50,7 @@ mod test {
         send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_type_definition(test_case.clone(), None);
+        let test_result = test_type_definition(test_case.clone(), &Position::default(), None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -74,8 +72,7 @@ mod test {
     ) {
         let resp = test_server::responses::get_type_definition_response(response_num).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
-        let test_case = TestCase::new(get_dummy_server_path(), source_file)
-            .cursor_pos(Some(Position::default()));
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
             .get_lspresso_dir()
             .expect("Failed to get test case's root directory");
@@ -83,7 +80,11 @@ mod test {
         send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_type_definition(test_case, Some(&resp)));
+        lspresso_shot!(test_type_definition(
+            test_case,
+            &Position::default(),
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -103,12 +104,12 @@ pub fn main() {
                 NonZeroU32::new(5).unwrap(),
                 "rustAnalyzer/Indexing".to_string(),
             ))
-            .cursor_pos(Some(Position::new(5, 9)))
             .timeout(Duration::from_secs(20))
             .other_file(cargo_dot_toml());
 
         lspresso_shot!(test_type_definition(
             test_case,
+            &Position::new(5, 9),
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {


### PR DESCRIPTION
- Adds `textDocument/selectionRange`
- Since this method takes a `positions` parameter, it's become very clear that accepting the cursor position implicitly via the `TestCase` doesn't make sense. In this PR's second commit, I've reworked all the other `test_*` functions that require a cursor position as part of the request to accept a `cursor_position` parameter.
	- I've left the `cursor_pos` field in the `TestCase` struct because in the future, it may make sense to use the `cursor_pos` field to define a starting position from which the user can specify a set of edits/cursor movements to make. One situation this could be useful for is testing completion, in which a server properly receiving incremental text document updates is something that should be tested. 