### PR TITLE
refactor(lib): split up types.rs into multiple files, refactor diffing logic

### DIFF
--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -19,16 +19,30 @@ use std::{
 };
 
 use types::{
-    CleanResponse, CodeLensMismatchError, CodeLensResolveMismatchError, CompletionMismatchError,
-    CompletionResult, DeclarationMismatchError, DefinitionMismatchError, DiagnosticMismatchError,
-    DocumentHighlightMismatchError, DocumentLinkMismatchError, DocumentLinkResolveMismatchError,
-    DocumentSymbolMismatchError, Empty, EmptyResult, FoldingRangeMismatchError,
-    FormattingMismatchError, FormattingResult, HoverMismatchError, ImplementationMismatchError,
-    IncomingCallsMismatchError, OutgoingCallsMismatchError, PrepareCallHierachyMismatchError,
-    ReferencesMismatchError, RenameMismatchError, SelectionRangeMismatchError,
-    SemanticTokensFullDeltaMismatchError, SemanticTokensFullMismatchError,
-    SemanticTokensRangeMismatchError, TestCase, TestError, TestResult, TestType, TimeoutError,
-    TypeDefinitionMismatchError,
+    call_hierarchy::{
+        IncomingCallsMismatchError, OutgoingCallsMismatchError, PrepareCallHierachyMismatchError,
+    },
+    code_lens::{CodeLensMismatchError, CodeLensResolveMismatchError},
+    completion::{CompletionMismatchError, CompletionResult},
+    declaration::DeclarationMismatchError,
+    definition::DefinitionMismatchError,
+    diagnostic::DiagnosticMismatchError,
+    document_highlight::DocumentHighlightMismatchError,
+    document_link::{DocumentLinkMismatchError, DocumentLinkResolveMismatchError},
+    document_symbol::DocumentSymbolMismatchError,
+    folding_range::FoldingRangeMismatchError,
+    formatting::{FormattingMismatchError, FormattingResult},
+    hover::HoverMismatchError,
+    implementation::ImplementationMismatchError,
+    references::ReferencesMismatchError,
+    rename::RenameMismatchError,
+    selection_range::SelectionRangeMismatchError,
+    semantic_tokens::{
+        SemanticTokensFullDeltaMismatchError, SemanticTokensFullMismatchError,
+        SemanticTokensRangeMismatchError,
+    },
+    type_definition::TypeDefinitionMismatchError,
+    CleanResponse, Empty, EmptyResult, TestCase, TestError, TestResult, TestType, TimeoutError,
 };
 
 /// Intended to be used as a wrapper for `lspresso-shot` testing functions. If the

--- a/lspresso-shot/types/call_hierarchy.rs
+++ b/lspresso-shot/types/call_hierarchy.rs
@@ -1,7 +1,10 @@
-use lsp_types::{CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall};
+use lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Range, SymbolKind,
+    SymbolTag, Uri,
+};
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{clean_uri, compare::Compare, CleanResponse, Empty, TestCase, TestResult};
 
 impl Empty for Vec<CallHierarchyItem> {}
 impl Empty for Vec<CallHierarchyIncomingCall> {}
@@ -46,8 +49,7 @@ impl std::fmt::Display for IncomingCallsMismatchError {
             "Test {}: Incorrect IncomingCalls response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
-        Ok(())
+        <Vec<CallHierarchyIncomingCall>>::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }
 
@@ -65,8 +67,7 @@ impl std::fmt::Display for OutgoingCallsMismatchError {
             "Test {}: Incorrect OutgoingCalls response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
-        Ok(())
+        <Vec<CallHierarchyOutgoingCall>>::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }
 
@@ -84,7 +85,162 @@ impl std::fmt::Display for PrepareCallHierachyMismatchError {
             "Test {}: Incorrect Prepare Call Hierarchy response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Prepare Call Hierarchy", &self.expected, &self.actual, 0)?;
+        <Vec<CallHierarchyItem>>::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for CallHierarchyIncomingCall {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CallHierarchyIncomingCall {{")?;
+        CallHierarchyItem::compare(
+            f,
+            Some("from"),
+            &expected.from,
+            &actual.from,
+            depth + 1,
+            override_color,
+        )?;
+        <Vec<Range>>::compare(
+            f,
+            Some("from_ranges"),
+            &expected.from_ranges,
+            &actual.from_ranges,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CallHierarchyItem {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CallHierarchyItem {{")?;
+        <String>::compare(
+            f,
+            Some("name"),
+            &expected.name,
+            &actual.name,
+            depth + 1,
+            override_color,
+        )?;
+        <SymbolKind>::compare(
+            f,
+            Some("kind"),
+            &expected.kind,
+            &actual.kind,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<SymbolTag>>>::compare(
+            f,
+            Some("tags"),
+            &expected.tags,
+            &actual.tags,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("detail"),
+            &expected.detail,
+            &actual.detail,
+            depth + 1,
+            override_color,
+        )?;
+        Uri::compare(
+            f,
+            Some("uri"),
+            &expected.uri,
+            &actual.uri,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("selection_range"),
+            &expected.selection_range,
+            &actual.selection_range,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<serde_json::Value>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}", padding = "  ".repeat(depth))?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CallHierarchyOutgoingCall {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CallHierarchyOutgoingCall {{")?;
+        CallHierarchyItem::compare(
+            f,
+            Some("to"),
+            &expected.to,
+            &actual.to,
+            depth + 1,
+            override_color,
+        )?;
+        <Vec<Range>>::compare(
+            f,
+            Some("from_ranges"),
+            &expected.from_ranges,
+            &actual.from_ranges,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
     }
 }

--- a/lspresso-shot/types/call_hierarchy.rs
+++ b/lspresso-shot/types/call_hierarchy.rs
@@ -1,0 +1,90 @@
+use lsp_types::{CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall};
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for Vec<CallHierarchyItem> {}
+impl Empty for Vec<CallHierarchyIncomingCall> {}
+impl Empty for Vec<CallHierarchyOutgoingCall> {}
+
+impl CleanResponse for Vec<CallHierarchyItem> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for item in &mut self {
+            item.uri = clean_uri(&item.uri, test_case)?;
+        }
+        Ok(self)
+    }
+}
+impl CleanResponse for Vec<CallHierarchyIncomingCall> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for call in &mut self {
+            call.from.uri = clean_uri(&call.from.uri, test_case)?;
+        }
+        Ok(self)
+    }
+}
+impl CleanResponse for Vec<CallHierarchyOutgoingCall> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for call in &mut self {
+            call.to.uri = clean_uri(&call.to.uri, test_case)?;
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct IncomingCallsMismatchError {
+    pub test_id: String,
+    pub expected: Vec<CallHierarchyIncomingCall>,
+    pub actual: Vec<CallHierarchyIncomingCall>,
+}
+
+impl std::fmt::Display for IncomingCallsMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect IncomingCalls response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct OutgoingCallsMismatchError {
+    pub test_id: String,
+    pub expected: Vec<CallHierarchyOutgoingCall>,
+    pub actual: Vec<CallHierarchyOutgoingCall>,
+}
+
+impl std::fmt::Display for OutgoingCallsMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect OutgoingCalls response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct PrepareCallHierachyMismatchError {
+    pub test_id: String,
+    pub expected: Vec<CallHierarchyItem>,
+    pub actual: Vec<CallHierarchyItem>,
+}
+
+impl std::fmt::Display for PrepareCallHierachyMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Prepare Call Hierarchy response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Prepare Call Hierarchy", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/code_lens.rs
+++ b/lspresso-shot/types/code_lens.rs
@@ -1,0 +1,44 @@
+use lsp_types::CodeLens;
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for CodeLens {}
+impl Empty for Vec<CodeLens> {}
+
+impl CleanResponse for CodeLens {}
+impl CleanResponse for Vec<CodeLens> {}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct CodeLensMismatchError {
+    pub test_id: String,
+    pub expected: Vec<CodeLens>,
+    pub actual: Vec<CodeLens>,
+}
+
+impl std::fmt::Display for CodeLensMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect CodeLens response:", self.test_id)?;
+        write_fields_comparison(f, "CodeLens", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct CodeLensResolveMismatchError {
+    pub test_id: String,
+    pub expected: CodeLens,
+    pub actual: CodeLens,
+}
+
+impl std::fmt::Display for CodeLensResolveMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect CodeLens Resolve response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "CodeLens", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/compare.rs
+++ b/lspresso-shot/types/compare.rs
@@ -1,0 +1,474 @@
+use std::collections::HashMap;
+
+use anstyle::{AnsiColor, Color, Style};
+use lsp_types::{Position, Range, Uri};
+use serde::Serialize;
+
+pub const GREEN: Option<Color> = Some(anstyle::Color::Ansi(AnsiColor::Green));
+pub const RED: Option<Color> = Some(anstyle::Color::Ansi(AnsiColor::Red));
+
+pub fn paint(color: Option<impl Into<Color>>, text: &str) -> String {
+    let style = Style::new().fg_color(color.map(Into::into));
+    format!("{style}{text}{style:#}")
+}
+
+// Delete this?
+#[macro_export]
+macro_rules! type_name {
+    ($t:ty) => {{
+        let full_name = type_name::<$t>();
+        full_name.rsplit("::").next().unwrap_or(full_name)
+    }};
+}
+
+pub fn cmp_fallback<T: std::fmt::Debug + PartialEq>(
+    f: &mut std::fmt::Formatter<'_>,
+    expected: &T,
+    actual: &T,
+    depth: usize,
+    name: Option<&str>,
+    override_color: Option<anstyle::Color>,
+) -> std::fmt::Result {
+    let padding = "  ".repeat(depth);
+    let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+    if expected == actual {
+        writeln!(
+            f,
+            "{padding}{name_str}{}",
+            paint(
+                override_color.unwrap_or(GREEN.unwrap()).into(),
+                &format!("{expected:?}")
+            )
+        )?;
+    } else {
+        writeln!(
+            f,
+            "{padding}{name_str}\n{}",
+            paint(
+                override_color.unwrap_or(RED.unwrap()).into(),
+                &format!("{padding}  Expected: {expected:?}\n{padding}  Actual: {actual:?}")
+            )
+        )?;
+    }
+
+    Ok(())
+}
+
+pub trait Compare {
+    // TODO: Add `=()` once default associated types are stabilized
+    type Nested1: Compare;
+    type Nested2: Compare;
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result
+    where
+        Self: std::fmt::Debug + PartialEq,
+    {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        if expected == actual {
+            writeln!(
+                f,
+                "{padding}{name_str}:{}",
+                paint(
+                    override_color.unwrap_or(GREEN.unwrap()).into(),
+                    &format!("{expected:?}")
+                )
+            )?;
+        } else {
+            writeln!(
+                f,
+                "{padding}{name_str}\n{}",
+                paint(
+                    override_color.unwrap_or(RED.unwrap()).into(),
+                    &format!("{padding}  Expected: {expected:?}\n{padding}  Actual: {actual:?}")
+                )
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl Compare for () {
+    type Nested1 = ();
+    type Nested2 = ();
+}
+
+impl Compare for bool {
+    type Nested1 = ();
+    type Nested2 = ();
+}
+
+impl Compare for serde_json::Number {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for serde_json::Value {
+    type Nested1 = ();
+    type Nested2 = ();
+    #[allow(clippy::too_many_lines)]
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Null, Self::Null) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}{}",
+                    paint(override_color.unwrap_or(GREEN.unwrap()).into(), "null")
+                )?;
+            }
+            (Self::Bool(expected_b), Self::Bool(actual_b)) => {
+                writeln!(f, "{padding}{name_str}Value::Bool (")?;
+                bool::compare(f, None, expected_b, actual_b, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Number(expected_num), Self::Number(actual_num)) => {
+                writeln!(f, "{padding}{name_str}Value::Number (")?;
+                serde_json::Number::compare(
+                    f,
+                    None,
+                    expected_num,
+                    actual_num,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::String(expected_str), Self::String(actual_str)) => {
+                writeln!(f, "{padding}{name_str}Value::String (")?;
+                String::compare(f, name, expected_str, actual_str, depth, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Array(expected_vec), Self::Array(actual_vec)) => {
+                writeln!(f, "{padding}{name_str}Value::Array (")?;
+                <Vec<Self>>::compare(f, name, expected_vec, actual_vec, depth, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Object(expected_map), Self::Object(actual_map)) => {
+                writeln!(f, "{padding}{name_str}Value::Object (")?;
+                <serde_json::Map<_, _>>::compare(
+                    f,
+                    name,
+                    expected_map,
+                    actual_map,
+                    depth,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for String {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for Position {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}Position {{")?;
+        u32::compare(f, name, &expected.line, &actual.line, depth, override_color)?;
+        u32::compare(
+            f,
+            name,
+            &expected.character,
+            &actual.character,
+            depth,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+        Ok(())
+    }
+}
+
+impl Compare for u32 {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for i32 {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for Range {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}:"));
+        writeln!(f, "{padding}{name_str} Range {{")?;
+        Position::compare(
+            f,
+            Some("start"),
+            &expected.start,
+            &actual.start,
+            depth + 1,
+            override_color,
+        )?;
+        Position::compare(
+            f,
+            Some("end"),
+            &expected.end,
+            &actual.end,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+        Ok(())
+    }
+}
+
+impl<T> Compare for Option<T>
+where
+    T: std::fmt::Debug + PartialEq + Compare,
+{
+    type Nested1 = T;
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Some(expected), Some(actual)) => {
+                T::compare(f, name, expected, actual, depth, override_color)?;
+            }
+            (None, None) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}{}",
+                    paint(override_color.unwrap_or(GREEN.unwrap()).into(), "None")
+                )?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        Ok(())
+    }
+}
+
+impl<T> Compare for Vec<T>
+where
+    T: Clone + std::fmt::Debug + PartialEq + Compare,
+{
+    type Nested1 = T;
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        if expected == actual {
+            writeln!(
+                f,
+                "{padding}{name_str}{}",
+                paint(
+                    override_color.unwrap_or(GREEN.unwrap()).into(),
+                    &format!("{expected:?}")
+                )
+            )?;
+        } else {
+            writeln!(f, "{padding}{name_str}[")?;
+            let expected_len = expected.len();
+            let actual_len = actual.len();
+            for (i, (exp, act)) in expected.iter().zip(actual.iter()).enumerate() {
+                T::compare(
+                    f,
+                    Some(&format!("[{i}]")),
+                    exp,
+                    act,
+                    depth + 1,
+                    override_color,
+                )?;
+            }
+            match expected_len.cmp(&actual_len) {
+                std::cmp::Ordering::Less => {
+                    writeln!(f, "{padding}  Additional actual items:")?;
+                    for (i, act) in actual.iter().enumerate().skip(expected_len) {
+                        T::compare(
+                            f,
+                            Some(&format!("[{i}]")),
+                            &act.clone(),
+                            &act.clone(),
+                            depth + 1,
+                            override_color.unwrap_or(RED.unwrap()).into(),
+                        )?;
+                    }
+                }
+                std::cmp::Ordering::Equal => {}
+                std::cmp::Ordering::Greater => {
+                    writeln!(f, "{padding}  Additional expected items:")?;
+                    for (i, exp) in expected.iter().enumerate().skip(actual_len) {
+                        T::compare(
+                            f,
+                            Some(&format!("[{i}]")),
+                            &exp.clone(),
+                            &exp.clone(),
+                            depth + 1,
+                            override_color.unwrap_or(RED.unwrap()).into(),
+                        )?;
+                    }
+                }
+            }
+            writeln!(f, "{padding}]")?;
+        }
+        Ok(())
+    }
+}
+
+impl<T, U> Compare for serde_json::Map<T, U>
+where
+    T: serde::Serialize,
+    U: serde::Serialize,
+    Self: PartialEq + Serialize,
+{
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        let expected_str = serde_json::to_string(expected).unwrap();
+        if expected == actual {
+            writeln!(
+                f,
+                "{padding}{name_str}{}",
+                paint(
+                    override_color.unwrap_or(GREEN.unwrap()).into(),
+                    &expected_str
+                )
+            )?;
+        } else {
+            let actual_str = serde_json::to_string(actual).unwrap();
+            cmp_fallback(f, &expected_str, &actual_str, depth, name, override_color)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<T, U> Compare for HashMap<T, U>
+where
+    T: Compare + std::cmp::Eq + std::hash::Hash + std::fmt::Debug,
+    U: Compare + std::cmp::PartialEq + std::fmt::Debug,
+{
+    type Nested1 = T;
+    type Nested2 = U;
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for Uri {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}

--- a/lspresso-shot/types/completion.rs
+++ b/lspresso-shot/types/completion.rs
@@ -1,0 +1,185 @@
+use lsp_types::{CompletionItem, CompletionList, CompletionResponse};
+use thiserror::Error;
+
+use super::{paint, write_fields_comparison, CleanResponse, Empty, RED};
+
+impl Empty for CompletionResponse {}
+
+impl CleanResponse for CompletionResponse {}
+
+// `textDocument/completion` is a bit different from other requests. Servers commonly
+// send a *bunch* of completion items and rely on the editor's lsp client to filter
+// them out/ display the most relevant ones first. This is fine, but it means that
+// doing a simple equality check for this isn't realistic and would be a serious
+// pain for library consumers. I'd like to experiment with the different ways we
+// can handle this, but for now we'll just allow for exact matching, and a simple
+// "contains" check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompletionResult {
+    /// Expect this exact set of completion items in the provided order
+    Exact(CompletionResponse),
+    /// Expect to at least see these completion items in any order.
+    /// NOTE: This discards the `CompletionList.is_incomplete` field and only
+    /// considers `CompletionList.items`
+    Contains(Vec<CompletionItem>),
+}
+
+impl CompletionResult {
+    /// Compares the expected results in `self` to the `actual` results, respecting
+    /// the intended behavior for each enum variant of `Self`
+    ///
+    /// Returns true if the two are considered equal, false otherwise
+    #[must_use]
+    pub fn results_satisfy(&self, actual: &CompletionResponse) -> bool {
+        match self {
+            Self::Contains(expected_results) => {
+                let actual_items = match actual {
+                    CompletionResponse::Array(a) => a,
+                    CompletionResponse::List(CompletionList { items, .. }) => items,
+                };
+                let mut expected = expected_results.clone();
+                for item in actual_items {
+                    if let Some(i) = expected
+                        .iter()
+                        .enumerate()
+                        .find(|(_, e)| *e == item)
+                        .map(|(i, _)| i)
+                    {
+                        expected.remove(i);
+                    };
+                }
+
+                expected.is_empty()
+            }
+            Self::Exact(expected_results) => match (expected_results, actual) {
+                (CompletionResponse::Array(expected), CompletionResponse::Array(actual)) => {
+                    expected == actual
+                }
+                (
+                    CompletionResponse::List(CompletionList {
+                        is_incomplete: expected_is_incomplete,
+                        items: expected_items,
+                    }),
+                    CompletionResponse::List(CompletionList {
+                        is_incomplete: actual_is_incomplete,
+                        items: actual_items,
+                    }),
+                ) => {
+                    expected_is_incomplete == actual_is_incomplete && expected_items == actual_items
+                }
+                (CompletionResponse::Array(_), CompletionResponse::List(_))
+                | (CompletionResponse::List(_), CompletionResponse::Array(_)) => false,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct CompletionMismatchError {
+    pub test_id: String,
+    pub expected: CompletionResult,
+    pub actual: CompletionResponse,
+}
+
+// TODO: Cleanup/ consolidate this logic with Self::compare_results
+impl std::fmt::Display for CompletionMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.expected {
+            CompletionResult::Contains(expected_results) => {
+                let actual_items = match &self.actual {
+                    CompletionResponse::Array(a) => a,
+                    CompletionResponse::List(CompletionList { items, .. }) => items,
+                };
+                let mut expected = expected_results.clone();
+                for item in actual_items {
+                    if let Some(i) = expected
+                        .iter()
+                        .enumerate()
+                        .find(|(_, e)| **e == *item)
+                        .map(|(i, _)| i)
+                    {
+                        expected.remove(i);
+                    };
+                }
+
+                writeln!(
+                    f,
+                    "Unprovided item{}:",
+                    if expected.len() > 1 { "s" } else { "" }
+                )?;
+                for item in &expected {
+                    writeln!(
+                        f,
+                        "{}",
+                        paint(RED, &format!("{}", serde_json::to_value(item).unwrap()))
+                    )?;
+                }
+                writeln!(
+                    f,
+                    "\nProvided item{}:",
+                    if actual_items.len() > 1 { "s" } else { "" }
+                )?;
+                for item in actual_items {
+                    writeln!(
+                        f,
+                        "{}",
+                        paint(RED, &format!("{}", serde_json::to_value(item).unwrap()))
+                    )?;
+                }
+            }
+            CompletionResult::Exact(expected_results) => match (expected_results, &self.actual) {
+                (CompletionResponse::Array(_), CompletionResponse::Array(_))
+                | (CompletionResponse::List(_), CompletionResponse::List(_)) => {
+                    write_fields_comparison(
+                        f,
+                        "CompletionResponse",
+                        expected_results,
+                        &self.actual,
+                        0,
+                    )?;
+                }
+                // Different completion types, indicate so and compare the inner items
+                (
+                    CompletionResponse::Array(expected_items),
+                    CompletionResponse::List(CompletionList {
+                        items: actual_items,
+                        ..
+                    }),
+                ) => {
+                    writeln!(
+                        f,
+                        "Expected `CompletionResponse::Array`, got `CompletionResponse::List`"
+                    )?;
+                    write_fields_comparison(
+                        f,
+                        "CompletionResponse",
+                        expected_items,
+                        actual_items,
+                        0,
+                    )?;
+                }
+                (
+                    CompletionResponse::List(CompletionList {
+                        items: expected_items,
+                        ..
+                    }),
+                    CompletionResponse::Array(actual_items),
+                ) => {
+                    writeln!(
+                        f,
+                        "Expected `CompletionResponse::List`, got `CompletionResponse::Array`"
+                    )?;
+                    write_fields_comparison(
+                        f,
+                        "CompletionResponse",
+                        expected_items,
+                        actual_items,
+                        0,
+                    )?;
+                }
+            },
+        };
+
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/completion.rs
+++ b/lspresso-shot/types/completion.rs
@@ -1,7 +1,14 @@
-use lsp_types::{CompletionItem, CompletionList, CompletionResponse};
+use lsp_types::{
+    Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionItemTag,
+    CompletionList, CompletionResponse, CompletionTextEdit, Documentation, InsertReplaceEdit,
+    InsertTextFormat, InsertTextMode, MarkupContent, Range, TextEdit,
+};
 use thiserror::Error;
 
-use super::{paint, write_fields_comparison, CleanResponse, Empty, RED};
+use super::{
+    compare::{cmp_fallback, paint, Compare, RED},
+    CleanResponse, Empty,
+};
 
 impl Empty for CompletionResponse {}
 
@@ -83,6 +90,7 @@ pub struct CompletionMismatchError {
 
 // TODO: Cleanup/ consolidate this logic with Self::compare_results
 impl std::fmt::Display for CompletionMismatchError {
+    #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.expected {
             CompletionResult::Contains(expected_results) => {
@@ -130,12 +138,13 @@ impl std::fmt::Display for CompletionMismatchError {
             CompletionResult::Exact(expected_results) => match (expected_results, &self.actual) {
                 (CompletionResponse::Array(_), CompletionResponse::Array(_))
                 | (CompletionResponse::List(_), CompletionResponse::List(_)) => {
-                    write_fields_comparison(
+                    <CompletionResponse>::compare(
                         f,
-                        "CompletionResponse",
+                        None,
                         expected_results,
                         &self.actual,
                         0,
+                        None,
                     )?;
                 }
                 // Different completion types, indicate so and compare the inner items
@@ -150,12 +159,13 @@ impl std::fmt::Display for CompletionMismatchError {
                         f,
                         "Expected `CompletionResponse::Array`, got `CompletionResponse::List`"
                     )?;
-                    write_fields_comparison(
+                    <Vec<CompletionItem>>::compare(
                         f,
-                        "CompletionResponse",
+                        Some("CompletionResponse"),
                         expected_items,
                         actual_items,
                         0,
+                        None,
                     )?;
                 }
                 (
@@ -169,17 +179,510 @@ impl std::fmt::Display for CompletionMismatchError {
                         f,
                         "Expected `CompletionResponse::List`, got `CompletionResponse::Array`"
                     )?;
-                    write_fields_comparison(
+                    <Vec<CompletionItem>>::compare(
                         f,
-                        "CompletionResponse",
+                        Some("CompletionResponse"),
                         expected_items,
                         actual_items,
                         0,
+                        None,
                     )?;
                 }
             },
         };
 
         Ok(())
+    }
+}
+
+impl Compare for CompletionResponse {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Array(expected), Self::Array(actual)) => {
+                writeln!(f, "{padding}{name_str}CompletionResponse::Array (")?;
+                <Vec<CompletionItem>>::compare(
+                    f,
+                    None,
+                    expected,
+                    actual,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (
+                Self::List(CompletionList {
+                    is_incomplete: expected_is_incomplete,
+                    items: expected_items,
+                }),
+                Self::List(CompletionList {
+                    is_incomplete: actual_is_incomplete,
+                    items: actual_items,
+                }),
+            ) => {
+                writeln!(f, "{padding}{name_str}CompletionResponse::List (")?;
+                bool::compare(
+                    f,
+                    Some("is_incomplete"),
+                    expected_is_incomplete,
+                    actual_is_incomplete,
+                    depth + 1,
+                    override_color,
+                )?;
+                <Vec<CompletionItem>>::compare(
+                    f,
+                    Some("items"),
+                    expected_items,
+                    actual_items,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => {
+                cmp_fallback(f, expected, actual, depth, name, override_color)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Compare for CompletionItem {
+    type Nested1 = ();
+    type Nested2 = ();
+    #[allow(clippy::too_many_lines)]
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CompletionItem {{")?;
+        String::compare(
+            f,
+            Some("label"),
+            &expected.label,
+            &actual.label,
+            depth,
+            override_color,
+        )?;
+        <Option<CompletionItemLabelDetails>>::compare(
+            f,
+            Some("label_details"),
+            &expected.label_details,
+            &actual.label_details,
+            depth,
+            override_color,
+        )?;
+        <Option<CompletionItemKind>>::compare(
+            f,
+            Some("kind"),
+            &expected.kind,
+            &actual.kind,
+            depth,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("detail"),
+            &expected.detail,
+            &actual.detail,
+            depth,
+            override_color,
+        )?;
+        <Option<Documentation>>::compare(
+            f,
+            Some("documentation"),
+            &expected.documentation,
+            &actual.documentation,
+            depth,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("deprecated"),
+            &expected.deprecated,
+            &actual.deprecated,
+            depth,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("preselect"),
+            &expected.preselect,
+            &actual.preselect,
+            depth,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("sort_text"),
+            &expected.sort_text,
+            &actual.sort_text,
+            depth,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("filter_text"),
+            &expected.filter_text,
+            &actual.filter_text,
+            depth,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("insert_text"),
+            &expected.insert_text,
+            &actual.insert_text,
+            depth,
+            override_color,
+        )?;
+        <Option<InsertTextFormat>>::compare(
+            f,
+            Some("insert_text_format"),
+            &expected.insert_text_format,
+            &actual.insert_text_format,
+            depth,
+            override_color,
+        )?;
+        <Option<InsertTextMode>>::compare(
+            f,
+            Some("insert_text_mode"),
+            &expected.insert_text_mode,
+            &actual.insert_text_mode,
+            depth,
+            override_color,
+        )?;
+        <Option<CompletionTextEdit>>::compare(
+            f,
+            Some("text_edit"),
+            &expected.text_edit,
+            &actual.text_edit,
+            depth,
+            override_color,
+        )?;
+        <Option<Vec<TextEdit>>>::compare(
+            f,
+            Some("additional_text_edits"),
+            &expected.additional_text_edits,
+            &actual.additional_text_edits,
+            depth,
+            override_color,
+        )?;
+        <Option<Command>>::compare(
+            f,
+            Some("command"),
+            &expected.command,
+            &actual.command,
+            depth,
+            override_color,
+        )?;
+        <Option<Vec<String>>>::compare(
+            f,
+            Some("commit_characters"),
+            &expected.commit_characters,
+            &actual.commit_characters,
+            depth,
+            override_color,
+        )?;
+        <Option<serde_json::Value>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth,
+            override_color,
+        )?;
+        <Option<Vec<CompletionItemTag>>>::compare(
+            f,
+            Some("tags"),
+            &expected.tags,
+            &actual.tags,
+            depth,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CompletionItemLabelDetails {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CompletionItemLabelDetails {{")?;
+        <Option<String>>::compare(
+            f,
+            Some("detail"),
+            &expected.detail,
+            &actual.detail,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("description"),
+            &expected.description,
+            &actual.description,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CompletionItemKind {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for Documentation {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::String(expected), Self::String(actual)) => {
+                writeln!(f, "{padding}{name_str}Documentation::String (")?;
+                String::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::MarkupContent(expected), Self::MarkupContent(actual)) => {
+                writeln!(f, "{padding}{name_str}Documentation::MarkupContent (")?;
+                MarkupContent::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => {
+                cmp_fallback(f, expected, actual, depth, name, override_color)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for InsertTextFormat {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for InsertTextMode {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for CompletionTextEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Edit(expected_edit), Self::Edit(actual_edit)) => {
+                writeln!(f, "{padding}{name_str}CompletionTextEdit::Edit (")?;
+                TextEdit::compare(
+                    f,
+                    None,
+                    expected_edit,
+                    actual_edit,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::InsertAndReplace(expected_text), Self::InsertAndReplace(actual_text)) => {
+                writeln!(f, "{padding}{name_str}CompletionTextEdit::InsertText (")?;
+                InsertReplaceEdit::compare(
+                    f,
+                    None,
+                    expected_text,
+                    actual_text,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => {
+                cmp_fallback(f, expected, actual, depth, name, override_color)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for InsertReplaceEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}InsertReplaceEdit {{")?;
+        String::compare(
+            f,
+            Some("new_text"),
+            &expected.new_text,
+            &actual.new_text,
+            depth,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("insert"),
+            &expected.insert,
+            &actual.insert,
+            depth,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("replace"),
+            &expected.replace,
+            &actual.replace,
+            depth,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for Command {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}Command {{")?;
+        String::compare(
+            f,
+            Some("title"),
+            &expected.title,
+            &actual.title,
+            depth,
+            override_color,
+        )?;
+        String::compare(
+            f,
+            Some("command"),
+            &expected.command,
+            &actual.command,
+            depth,
+            override_color,
+        )?;
+        <Option<Vec<serde_json::Value>>>::compare(
+            f,
+            Some("arguments"),
+            &expected.arguments,
+            &actual.arguments,
+            depth,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CompletionItemTag {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
     }
 }

--- a/lspresso-shot/types/declaration.rs
+++ b/lspresso-shot/types/declaration.rs
@@ -1,0 +1,23 @@
+use lsp_types::request::GotoDeclarationResponse;
+use thiserror::Error;
+
+use super::write_fields_comparison;
+
+#[derive(Debug, Error, PartialEq)]
+pub struct DeclarationMismatchError {
+    pub test_id: String,
+    pub expected: GotoDeclarationResponse,
+    pub actual: GotoDeclarationResponse,
+}
+
+impl std::fmt::Display for DeclarationMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect GotoDeclaration response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "GotoDeclaration", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/declaration.rs
+++ b/lspresso-shot/types/declaration.rs
@@ -1,7 +1,7 @@
 use lsp_types::request::GotoDeclarationResponse;
 use thiserror::Error;
 
-use super::write_fields_comparison;
+use super::compare::Compare as _;
 
 #[derive(Debug, Error, PartialEq)]
 pub struct DeclarationMismatchError {
@@ -17,7 +17,6 @@ impl std::fmt::Display for DeclarationMismatchError {
             "Test {}: Incorrect GotoDeclaration response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "GotoDeclaration", &self.expected, &self.actual, 0)?;
-        Ok(())
+        GotoDeclarationResponse::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }

--- a/lspresso-shot/types/definition.rs
+++ b/lspresso-shot/types/definition.rs
@@ -1,7 +1,7 @@
 use lsp_types::GotoDefinitionResponse;
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{clean_uri, compare::Compare as _, CleanResponse, Empty, TestCase, TestResult};
 
 impl Empty for GotoDefinitionResponse {}
 
@@ -40,7 +40,6 @@ impl std::fmt::Display for DefinitionMismatchError {
             "Test {}: Incorrect GotoDefinition response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "GotoDefinition", &self.expected, &self.actual, 0)?;
-        Ok(())
+        GotoDefinitionResponse::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }

--- a/lspresso-shot/types/definition.rs
+++ b/lspresso-shot/types/definition.rs
@@ -1,0 +1,46 @@
+use lsp_types::GotoDefinitionResponse;
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for GotoDefinitionResponse {}
+
+impl CleanResponse for GotoDefinitionResponse {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        match &mut self {
+            Self::Scalar(location) => {
+                location.uri = clean_uri(&location.uri, test_case)?;
+            }
+            Self::Array(locs) => {
+                for loc in locs {
+                    loc.uri = clean_uri(&loc.uri, test_case)?;
+                }
+            }
+            Self::Link(links) => {
+                for link in links {
+                    link.target_uri = clean_uri(&link.target_uri, test_case)?;
+                }
+            }
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct DefinitionMismatchError {
+    pub test_id: String,
+    pub expected: GotoDefinitionResponse,
+    pub actual: GotoDefinitionResponse,
+}
+
+impl std::fmt::Display for DefinitionMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect GotoDefinition response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "GotoDefinition", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/diagnostic.rs
+++ b/lspresso-shot/types/diagnostic.rs
@@ -1,0 +1,34 @@
+use lsp_types::Diagnostic;
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for Vec<Diagnostic> {}
+
+impl CleanResponse for Vec<Diagnostic> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for diagnostic in &mut self {
+            if let Some(info) = diagnostic.related_information.as_mut() {
+                for related in info {
+                    related.location.uri = clean_uri(&related.location.uri, test_case)?;
+                }
+            }
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct DiagnosticMismatchError {
+    pub test_id: String,
+    pub expected: Vec<Diagnostic>,
+    pub actual: Vec<Diagnostic>,
+}
+
+impl std::fmt::Display for DiagnosticMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect Diagnostic response:", self.test_id)?;
+        write_fields_comparison(f, "Diagnostics", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/diagnostic.rs
+++ b/lspresso-shot/types/diagnostic.rs
@@ -1,7 +1,14 @@
-use lsp_types::Diagnostic;
+use lsp_types::{
+    CodeDescription, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag,
+    Location, NumberOrString, Range, Uri,
+};
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{
+    clean_uri,
+    compare::{cmp_fallback, Compare},
+    CleanResponse, Empty, TestCase, TestResult,
+};
 
 impl Empty for Vec<Diagnostic> {}
 
@@ -28,7 +35,216 @@ pub struct DiagnosticMismatchError {
 impl std::fmt::Display for DiagnosticMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Diagnostic response:", self.test_id)?;
-        write_fields_comparison(f, "Diagnostics", &self.expected, &self.actual, 0)?;
+        <Vec<Diagnostic>>::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for Diagnostic {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}Diagnostic {{")?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<DiagnosticSeverity>>::compare(
+            f,
+            Some("severity"),
+            &expected.severity,
+            &actual.severity,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<NumberOrString>>::compare(
+            f,
+            Some("code"),
+            &expected.code,
+            &actual.code,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<CodeDescription>>::compare(
+            f,
+            Some("code_description"),
+            &expected.code_description,
+            &actual.code_description,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("source"),
+            &expected.source,
+            &actual.source,
+            depth + 1,
+            override_color,
+        )?;
+        String::compare(
+            f,
+            Some("message"),
+            &expected.message,
+            &actual.message,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<DiagnosticRelatedInformation>>>::compare(
+            f,
+            Some("related_information"),
+            &expected.related_information,
+            &actual.related_information,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<DiagnosticTag>>>::compare(
+            f,
+            Some("tags"),
+            &expected.tags,
+            &actual.tags,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<serde_json::Value>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
+    }
+}
+
+impl Compare for DiagnosticSeverity {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for NumberOrString {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        match (expected, actual) {
+            (Self::Number(expected_num), Self::Number(actual_num)) => {
+                i32::compare(f, name, expected_num, actual_num, depth, override_color)?;
+            }
+            (Self::String(expected_str), Self::String(actual_str)) => {
+                String::compare(f, name, expected_str, actual_str, depth, override_color)?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        Ok(())
+    }
+}
+
+impl Compare for CodeDescription {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CodeDescription {{")?;
+        Uri::compare(
+            f,
+            Some("href"),
+            &expected.href,
+            &actual.href,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for DiagnosticRelatedInformation {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}DiagnosticRelatedInformation {{")?;
+        Location::compare(
+            f,
+            Some("location"),
+            &expected.location,
+            &actual.location,
+            depth + 1,
+            override_color,
+        )?;
+        String::compare(
+            f,
+            Some("message"),
+            &expected.message,
+            &actual.message,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for DiagnosticTag {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
     }
 }

--- a/lspresso-shot/types/document_highlight.rs
+++ b/lspresso-shot/types/document_highlight.rs
@@ -1,0 +1,27 @@
+use lsp_types::DocumentHighlight;
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for Vec<DocumentHighlight> {}
+
+impl CleanResponse for Vec<DocumentHighlight> {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct DocumentHighlightMismatchError {
+    pub test_id: String,
+    pub expected: Vec<DocumentHighlight>,
+    pub actual: Vec<DocumentHighlight>,
+}
+
+impl std::fmt::Display for DocumentHighlightMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Document Highlight response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Document Highlight", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/document_link.rs
+++ b/lspresso-shot/types/document_link.rs
@@ -1,0 +1,65 @@
+use lsp_types::DocumentLink;
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for DocumentLink {}
+impl Empty for Vec<DocumentLink> {}
+
+impl CleanResponse for DocumentLink {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        if let Some(ref mut uri) = self.target {
+            *uri = clean_uri(uri, test_case)?;
+        }
+        Ok(self)
+    }
+}
+
+impl CleanResponse for Vec<DocumentLink> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for link in &mut self {
+            if let Some(ref mut uri) = link.target {
+                *uri = clean_uri(uri, test_case)?;
+            }
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct DocumentLinkMismatchError {
+    pub test_id: String,
+    pub expected: Vec<DocumentLink>,
+    pub actual: Vec<DocumentLink>,
+}
+
+impl std::fmt::Display for DocumentLinkMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Document Link response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Document Link", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct DocumentLinkResolveMismatchError {
+    pub test_id: String,
+    pub expected: DocumentLink,
+    pub actual: DocumentLink,
+}
+
+impl std::fmt::Display for DocumentLinkResolveMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Document Link Resolve response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Document Link", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/document_link.rs
+++ b/lspresso-shot/types/document_link.rs
@@ -1,7 +1,7 @@
-use lsp_types::DocumentLink;
+use lsp_types::{DocumentLink, Range, Uri};
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{clean_uri, compare::Compare, CleanResponse, Empty, TestCase, TestResult};
 
 impl Empty for DocumentLink {}
 impl Empty for Vec<DocumentLink> {}
@@ -40,8 +40,7 @@ impl std::fmt::Display for DocumentLinkMismatchError {
             "Test {}: Incorrect Document Link response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Document Link", &self.expected, &self.actual, 0)?;
-        Ok(())
+        <Vec<DocumentLink>>::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }
 
@@ -59,7 +58,58 @@ impl std::fmt::Display for DocumentLinkResolveMismatchError {
             "Test {}: Incorrect Document Link Resolve response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Document Link", &self.expected, &self.actual, 0)?;
+        DocumentLink::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for DocumentLink {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}DocumentLink {{")?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Uri>>::compare(
+            f,
+            Some("target"),
+            &expected.target,
+            &actual.target,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("tooltip"),
+            &expected.tooltip,
+            &actual.tooltip,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<serde_json::Value>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
     }
 }

--- a/lspresso-shot/types/document_symbol.rs
+++ b/lspresso-shot/types/document_symbol.rs
@@ -1,7 +1,14 @@
-use lsp_types::DocumentSymbolResponse;
+use lsp_types::{
+    DocumentSymbol, DocumentSymbolResponse, Location, Range, SymbolInformation, SymbolKind,
+    SymbolTag,
+};
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{
+    clean_uri,
+    compare::{cmp_fallback, paint, Compare, RED},
+    CleanResponse, Empty, TestCase, TestResult,
+};
 
 impl Empty for DocumentSymbolResponse {}
 
@@ -33,7 +40,240 @@ impl std::fmt::Display for DocumentSymbolMismatchError {
             "Test {}: Incorrect Document Symbol response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Document Symbols", &self.expected, &self.actual, 0)?;
+        DocumentSymbolResponse::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for DocumentSymbolResponse {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Flat(expected), Self::Flat(actual)) => {
+                writeln!(f, "{padding}{name_str}DocumentSymbolResponse::Flat (")?;
+                <Vec<SymbolInformation>>::compare(
+                    f,
+                    None,
+                    expected,
+                    actual,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Nested(expected), Self::Nested(actual)) => {
+                writeln!(f, "{padding}{name_str}DocumentSymbolResponse::Nested (")?;
+                <Vec<DocumentSymbol>>::compare(
+                    f,
+                    None,
+                    expected,
+                    actual,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}{}",
+                    paint(
+                        override_color.unwrap_or(RED.unwrap()).into(),
+                        &format!(
+                            "{padding}  Expected:\n{padding}    {expected:?}\n{padding}  Actual:\n{padding}    {actual:?}"
+                        )
+                    )
+                )?;
+            }
+        }
+
         Ok(())
+    }
+}
+
+impl Compare for DocumentSymbol {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}DocumentSymbol {{")?;
+        String::compare(
+            f,
+            Some("name"),
+            &expected.name,
+            &actual.name,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("detail"),
+            &expected.detail,
+            &actual.detail,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<SymbolTag>>>::compare(
+            f,
+            Some("tags"),
+            &expected.tags,
+            &actual.tags,
+            depth + 1,
+            override_color,
+        )?;
+        Option::compare(
+            f,
+            Some("deprecated"),
+            #[allow(deprecated)]
+            &expected.deprecated,
+            #[allow(deprecated)]
+            &actual.deprecated,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("selection_range"),
+            &expected.selection_range,
+            &actual.selection_range,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<Self>>>::compare(
+            f,
+            Some("children"),
+            &expected.children,
+            &actual.children,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SymbolInformation {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SymbolInformation {{")?;
+        String::compare(
+            f,
+            Some("name"),
+            &expected.name,
+            &actual.name,
+            depth + 1,
+            override_color,
+        )?;
+        SymbolKind::compare(
+            f,
+            Some("kind"),
+            &expected.kind,
+            &actual.kind,
+            depth + 1,
+            override_color,
+        )?;
+        Option::compare(
+            f,
+            Some("tags"),
+            &expected.tags,
+            &actual.tags,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("deprecated"),
+            #[allow(deprecated)]
+            &expected.deprecated,
+            #[allow(deprecated)]
+            &actual.deprecated,
+            depth + 1,
+            override_color,
+        )?;
+        Location::compare(
+            f,
+            Some("location"),
+            &expected.location,
+            &actual.location,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("container_name"),
+            &expected.container_name,
+            &actual.container_name,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SymbolKind {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for SymbolTag {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
     }
 }

--- a/lspresso-shot/types/document_symbol.rs
+++ b/lspresso-shot/types/document_symbol.rs
@@ -1,0 +1,39 @@
+use lsp_types::DocumentSymbolResponse;
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for DocumentSymbolResponse {}
+
+impl CleanResponse for DocumentSymbolResponse {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        match &mut self {
+            Self::Flat(syms) => {
+                for sym in syms {
+                    sym.location.uri = clean_uri(&sym.location.uri, test_case)?;
+                }
+            }
+            Self::Nested(_) => {}
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct DocumentSymbolMismatchError {
+    pub test_id: String,
+    pub expected: DocumentSymbolResponse,
+    pub actual: DocumentSymbolResponse,
+}
+
+impl std::fmt::Display for DocumentSymbolMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Document Symbol response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Document Symbols", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/folding_range.rs
+++ b/lspresso-shot/types/folding_range.rs
@@ -1,7 +1,10 @@
-use lsp_types::FoldingRange;
+use lsp_types::{FoldingRange, FoldingRangeKind};
 use thiserror::Error;
 
-use super::{write_fields_comparison, CleanResponse, Empty};
+use super::{
+    compare::{cmp_fallback, Compare},
+    CleanResponse, Empty,
+};
 
 impl Empty for Vec<FoldingRange> {}
 
@@ -17,7 +20,89 @@ pub struct FoldingRangeMismatchError {
 impl std::fmt::Display for FoldingRangeMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Folding Range response:", self.test_id)?;
-        write_fields_comparison(f, "FoldingRange", &self.expected, &self.actual, 0)?;
+        <Vec<FoldingRange>>::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for FoldingRange {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}FoldingRange {{")?;
+        u32::compare(
+            f,
+            Some("start_line"),
+            &expected.start_line,
+            &actual.start_line,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<u32>>::compare(
+            f,
+            Some("start_character"),
+            &expected.start_character,
+            &actual.start_character,
+            depth + 1,
+            override_color,
+        )?;
+        u32::compare(
+            f,
+            Some("end_line"),
+            &expected.end_line,
+            &actual.end_line,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<u32>>::compare(
+            f,
+            Some("end_character"),
+            &expected.end_character,
+            &actual.end_character,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<FoldingRangeKind>>::compare(
+            f,
+            Some("kind"),
+            &expected.kind,
+            &actual.kind,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<String>>::compare(
+            f,
+            Some("collapse_text"),
+            &expected.collapsed_text,
+            &actual.collapsed_text,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
+    }
+}
+
+impl Compare for FoldingRangeKind {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
     }
 }

--- a/lspresso-shot/types/folding_range.rs
+++ b/lspresso-shot/types/folding_range.rs
@@ -1,0 +1,23 @@
+use lsp_types::FoldingRange;
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for Vec<FoldingRange> {}
+
+impl CleanResponse for Vec<FoldingRange> {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct FoldingRangeMismatchError {
+    pub test_id: String,
+    pub expected: Vec<FoldingRange>,
+    pub actual: Vec<FoldingRange>,
+}
+
+impl std::fmt::Display for FoldingRangeMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Folding Range response:", self.test_id)?;
+        write_fields_comparison(f, "FoldingRange", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/formatting.rs
+++ b/lspresso-shot/types/formatting.rs
@@ -1,7 +1,7 @@
-use lsp_types::TextEdit;
+use lsp_types::{AnnotatedTextEdit, ChangeAnnotationIdentifier, Range, TextEdit};
 use thiserror::Error;
 
-use super::{write_fields_comparison, CleanResponse, Empty};
+use super::{compare::Compare, CleanResponse, Empty};
 
 impl Empty for FormattingResult {}
 impl Empty for Vec<TextEdit> {}
@@ -27,21 +27,121 @@ pub struct FormattingMismatchError {
 impl std::fmt::Display for FormattingMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Formatting response:", self.test_id)?;
-        match (&self.expected, &self.actual) {
-            (
-                FormattingResult::Response(expected_edits),
-                FormattingResult::Response(actual_edits),
-            ) => {
-                write_fields_comparison(f, "TextEdit", expected_edits, actual_edits, 0)?;
+        FormattingResult::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for FormattingResult {
+    type Nested1 = ();
+    type Nested2 = TextEdit;
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        _name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        match (expected, actual) {
+            (Self::EndState(expected_end_state), Self::EndState(actual_end_state)) => {
+                writeln!(f, "{padding}FormattingResult::EndState (")?;
+                String::compare(
+                    f,
+                    None,
+                    expected_end_state,
+                    actual_end_state,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
             }
-            (
-                FormattingResult::EndState(expected_end_state),
-                FormattingResult::EndState(actual_end_state),
-            ) => {
-                write_fields_comparison(f, "EndState", expected_end_state, actual_end_state, 0)?;
+            (Self::Response(expected_edits), Self::Response(actual_edits)) => {
+                writeln!(f, "{padding}FormattingResult::Response (")?;
+                <Vec<TextEdit>>::compare(
+                    f,
+                    None,
+                    expected_edits,
+                    actual_edits,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
             }
             _ => unreachable!(),
         }
+        Ok(())
+    }
+}
+
+impl Compare for AnnotatedTextEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}AnnotatedTextEdit {{")?;
+        TextEdit::compare(
+            f,
+            Some("text_edit"),
+            &expected.text_edit,
+            &actual.text_edit,
+            depth + 1,
+            override_color,
+        )?;
+        ChangeAnnotationIdentifier::compare(
+            f,
+            Some("annotation_id"),
+            &expected.annotation_id,
+            &actual.annotation_id,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for TextEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}TextEdit {{")?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        String::compare(
+            f,
+            Some("new_text"),
+            &expected.new_text,
+            &actual.new_text,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
     }
 }

--- a/lspresso-shot/types/formatting.rs
+++ b/lspresso-shot/types/formatting.rs
@@ -1,0 +1,47 @@
+use lsp_types::TextEdit;
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for FormattingResult {}
+impl Empty for Vec<TextEdit> {}
+
+impl CleanResponse for FormattingResult {}
+impl CleanResponse for Vec<TextEdit> {}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FormattingResult {
+    /// Check if the file's formatted state matches the expected contents
+    EndState(String),
+    /// Check if the server's response matches the exected edits
+    Response(Vec<TextEdit>),
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct FormattingMismatchError {
+    pub test_id: String,
+    pub expected: FormattingResult,
+    pub actual: FormattingResult,
+}
+
+impl std::fmt::Display for FormattingMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect Formatting response:", self.test_id)?;
+        match (&self.expected, &self.actual) {
+            (
+                FormattingResult::Response(expected_edits),
+                FormattingResult::Response(actual_edits),
+            ) => {
+                write_fields_comparison(f, "TextEdit", expected_edits, actual_edits, 0)?;
+            }
+            (
+                FormattingResult::EndState(expected_end_state),
+                FormattingResult::EndState(actual_end_state),
+            ) => {
+                write_fields_comparison(f, "EndState", expected_end_state, actual_end_state, 0)?;
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/hover.rs
+++ b/lspresso-shot/types/hover.rs
@@ -1,7 +1,12 @@
-use lsp_types::Hover;
+use lsp_types::{
+    Hover, HoverContents, LanguageString, MarkedString, MarkupContent, MarkupKind, Range,
+};
 use thiserror::Error;
 
-use super::{write_fields_comparison, CleanResponse, Empty};
+use super::{
+    compare::{cmp_fallback, Compare},
+    CleanResponse, Empty,
+};
 
 impl Empty for Hover {}
 
@@ -17,7 +22,210 @@ pub struct HoverMismatchError {
 impl std::fmt::Display for HoverMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Hover response:", self.test_id)?;
-        write_fields_comparison(f, "Hover", &self.expected, &self.actual, 0)?;
+        Hover::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for Hover {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}Hover {{")?;
+        HoverContents::compare(
+            f,
+            Some("contents"),
+            &expected.contents,
+            &actual.contents,
+            depth + 1,
+            override_color,
+        )?;
+        Option::<Range>::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for HoverContents {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Scalar(expected), Self::Scalar(actual)) => {
+                writeln!(f, "{padding}{name_str}HoverContents::Scalar (")?;
+                MarkedString::compare(
+                    f,
+                    Some("value"),
+                    expected,
+                    actual,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Array(expected), Self::Array(actual)) => {
+                writeln!(f, "{padding}{name_str}HoverContents::Array (")?;
+                <Vec<MarkedString>>::compare(
+                    f,
+                    Some("value"),
+                    expected,
+                    actual,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Markup(expected), Self::Markup(actual)) => {
+                writeln!(f, "{padding}{name_str}HoverContents::MarkupContent (")?;
+                MarkupContent::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for MarkupKind {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for MarkupContent {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}MarkupContent {{")?;
+        MarkupKind::compare(
+            f,
+            Some("kind"),
+            &expected.kind,
+            &actual.kind,
+            depth + 1,
+            override_color,
+        )?;
+        String::compare(
+            f,
+            Some("value"),
+            &expected.value,
+            &actual.value,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for MarkedString {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::String(expected), Self::String(actual)) => {
+                writeln!(f, "{padding}{name_str}MarkedString::String (")?;
+                String::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::LanguageString(expected), Self::LanguageString(actual)) => {
+                writeln!(f, "{padding}{name_str}MarkedString::LanguageString (")?;
+                LanguageString::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for LanguageString {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}LanguageString {{")?;
+        String::compare(
+            f,
+            Some("language"),
+            &expected.language,
+            &actual.language,
+            depth + 1,
+            override_color,
+        )?;
+        String::compare(
+            f,
+            Some("value"),
+            &expected.value,
+            &actual.value,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
     }
 }

--- a/lspresso-shot/types/hover.rs
+++ b/lspresso-shot/types/hover.rs
@@ -1,0 +1,23 @@
+use lsp_types::Hover;
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for Hover {}
+
+impl CleanResponse for Hover {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct HoverMismatchError {
+    pub test_id: String,
+    pub expected: Hover,
+    pub actual: Hover,
+}
+
+impl std::fmt::Display for HoverMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect Hover response:", self.test_id)?;
+        write_fields_comparison(f, "Hover", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/implementation.rs
+++ b/lspresso-shot/types/implementation.rs
@@ -1,0 +1,23 @@
+use lsp_types::request::GotoImplementationResponse;
+use thiserror::Error;
+
+use super::write_fields_comparison;
+
+#[derive(Debug, Error, PartialEq)]
+pub struct ImplementationMismatchError {
+    pub test_id: String,
+    pub expected: GotoImplementationResponse,
+    pub actual: GotoImplementationResponse,
+}
+
+impl std::fmt::Display for ImplementationMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Implementation response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/implementation.rs
+++ b/lspresso-shot/types/implementation.rs
@@ -1,7 +1,7 @@
 use lsp_types::request::GotoImplementationResponse;
 use thiserror::Error;
 
-use super::write_fields_comparison;
+use super::compare::Compare as _;
 
 #[derive(Debug, Error, PartialEq)]
 pub struct ImplementationMismatchError {
@@ -17,7 +17,6 @@ impl std::fmt::Display for ImplementationMismatchError {
             "Test {}: Incorrect Implementation response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Implementation", &self.expected, &self.actual, 0)?;
-        Ok(())
+        GotoImplementationResponse::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }

--- a/lspresso-shot/types/mod.rs
+++ b/lspresso-shot/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod call_hierarchy;
 pub mod code_lens;
+pub(crate) mod compare;
 pub mod completion;
 pub mod declaration;
 pub mod definition;
@@ -17,6 +18,7 @@ pub mod selection_range;
 pub mod semantic_tokens;
 pub mod type_definition;
 
+use crate::init_dot_lua::get_init_dot_lua;
 use crate::types::{
     call_hierarchy::{
         IncomingCallsMismatchError, OutgoingCallsMismatchError, PrepareCallHierachyMismatchError,
@@ -42,10 +44,8 @@ use crate::types::{
     },
     type_definition::TypeDefinitionMismatchError,
 };
-use crate::init_dot_lua::get_init_dot_lua;
 
 use std::{
-    collections::HashSet,
     env::temp_dir,
     fs,
     num::NonZeroU32,
@@ -54,7 +54,6 @@ use std::{
     time::Duration,
 };
 
-use anstyle::{AnsiColor, Color, Style};
 use lsp_types::{Position, Uri};
 use rand::distr::Distribution as _;
 use serde::{Deserialize, Serialize};
@@ -678,147 +677,6 @@ impl std::fmt::Display for TimeoutError {
 
         Ok(())
     }
-}
-
-const GREEN: Option<Color> = Some(anstyle::Color::Ansi(AnsiColor::Green));
-const RED: Option<Color> = Some(anstyle::Color::Ansi(AnsiColor::Red));
-
-fn paint(color: Option<impl Into<Color>>, text: &str) -> String {
-    let style = Style::new().fg_color(color.map(Into::into));
-    format!("{style}{text}{style:#}")
-}
-
-// TODO: Our rendering logic could probably use some cleanup/fxes
-fn compare_fields(
-    f: &mut std::fmt::Formatter<'_>,
-    indent: usize,
-    key: &str,
-    expected: &serde_json::Value,
-    actual: &serde_json::Value,
-) -> std::fmt::Result {
-    let padding = "  ".repeat(indent);
-    let key_render = format!("{key}: ");
-
-    if expected == actual {
-        writeln!(
-            f,
-            "{}",
-            paint(GREEN, &format!("{padding}{key_render}{expected}"))
-        )?;
-    } else {
-        // TODO: Pull in some sort of diffing library to make this more readable,
-        // as it can be very difficult to spot what's off when comparing long strings
-        let expected_render = if expected.is_string() {
-            format!("\n{padding}    {expected}")
-        } else {
-            format!(" {expected}")
-        };
-        let actual_render = if actual.is_string() {
-            format!("\n{padding}    {actual}")
-        } else {
-            format!(" {actual}")
-        };
-        writeln!(
-                f,
-                "{}",
-                paint(
-                    RED,
-                    &format!("{padding}{key_render}\n{padding}  Expected:{expected_render}\n{padding}  Actual:{actual_render}")
-                )
-            )?;
-    }
-
-    std::fmt::Result::Ok(())
-}
-
-fn write_fields_comparison<T: Serialize>(
-    f: &mut std::fmt::Formatter<'_>,
-    name: &str,
-    expected: &T,
-    actual: &T,
-    indent: usize,
-) -> std::fmt::Result {
-    let mut expected_value = serde_json::to_value(expected).unwrap();
-    let mut actual_value = serde_json::to_value(actual).unwrap();
-    let padding = "  ".repeat(indent);
-    let key_render = if indent == 0 {
-        String::new()
-    } else {
-        format!("{name}: ")
-    };
-
-    match expected_value {
-        serde_json::Value::Object(ref mut map) => {
-            let expected_keys: HashSet<_> = map.keys().map(|k| k.to_owned()).collect();
-            map.sort_keys(); // ensure a deterministic ordering
-            writeln!(f, "{padding}{key_render}{{",)?;
-            for (expected_key, expected_val) in &map.clone() {
-                let actual_val = actual_value
-                    .get(expected_key)
-                    .unwrap_or(&serde_json::Value::Null)
-                    .to_owned();
-                match expected_val {
-                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
-                        write_fields_comparison(
-                            f,
-                            expected_key,
-                            expected_val,
-                            &actual_val,
-                            indent + 1,
-                        )?;
-                    }
-                    _ => {
-                        compare_fields(f, indent + 1, expected_key, expected_val, &actual_val)?;
-                    }
-                }
-            }
-            // Display entries present in the `actual` map but not in the `expected` map
-            if let Some(ref mut actual_map) = actual_value.as_object_mut() {
-                actual_map.sort_keys(); // ensure a deterministic ordering
-                for (actual_key, actual_val) in actual_map
-                    .iter()
-                    .filter(|(k, _)| !expected_keys.contains(k.as_str()))
-                {
-                    compare_fields(
-                        f,
-                        indent + 1,
-                        actual_key,
-                        &serde_json::Value::Null,
-                        actual_val,
-                    )?;
-                }
-            }
-            writeln!(f, "{padding}}},")?;
-        }
-        serde_json::Value::Array(ref array) => {
-            writeln!(f, "{padding}{key_render}[")?;
-            for (i, expected_val) in array.iter().enumerate() {
-                let actual_val = actual_value
-                    .get(i)
-                    .unwrap_or(&serde_json::Value::Null)
-                    .to_owned();
-                write_fields_comparison(f, name, expected_val, &actual_val, indent + 1)?;
-            }
-            // Display entries present in the `actual` array but not in the `expected` array
-            for i in array.len()..actual_value.as_array().map_or(0, |a| a.len()) {
-                let actual_val = actual_value
-                    .get(i)
-                    .unwrap_or(&serde_json::Value::Null)
-                    .to_owned();
-                write_fields_comparison(
-                    f,
-                    name,
-                    &serde_json::Value::Null,
-                    &actual_val,
-                    indent + 1,
-                )?;
-            }
-            writeln!(f, "{padding}],")?;
-        }
-        _ => compare_fields(f, indent + 1, name, &expected_value, &actual_value)?,
-    }
-
-    Ok(())
 }
 
 pub(crate) trait Empty {

--- a/lspresso-shot/types/references.rs
+++ b/lspresso-shot/types/references.rs
@@ -1,7 +1,7 @@
 use lsp_types::Location;
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{clean_uri, compare::Compare as _, CleanResponse, Empty, TestCase, TestResult};
 
 impl Empty for Vec<Location> {}
 
@@ -24,7 +24,6 @@ pub struct ReferencesMismatchError {
 impl std::fmt::Display for ReferencesMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect References response:", self.test_id)?;
-        write_fields_comparison(f, "Location", &self.expected, &self.actual, 0)?;
-        Ok(())
+        <Vec<Location>>::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }

--- a/lspresso-shot/types/references.rs
+++ b/lspresso-shot/types/references.rs
@@ -1,0 +1,30 @@
+use lsp_types::Location;
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for Vec<Location> {}
+
+impl CleanResponse for Vec<Location> {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        for loc in &mut self {
+            loc.uri = clean_uri(&loc.uri, test_case)?;
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct ReferencesMismatchError {
+    pub test_id: String,
+    pub expected: Vec<Location>,
+    pub actual: Vec<Location>,
+}
+
+impl std::fmt::Display for ReferencesMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect References response:", self.test_id)?;
+        write_fields_comparison(f, "Location", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/rename.rs
+++ b/lspresso-shot/types/rename.rs
@@ -1,9 +1,18 @@
 use std::collections::HashMap;
 
-use lsp_types::{DocumentChangeOperation, DocumentChanges, ResourceOp, WorkspaceEdit};
+use lsp_types::{
+    AnnotatedTextEdit, ChangeAnnotationIdentifier, CreateFile, CreateFileOptions, DeleteFile,
+    DeleteFileOptions, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, RenameFile, RenameFileOptions, ResourceOp,
+    TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+};
 use thiserror::Error;
 
-use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+use super::{
+    clean_uri,
+    compare::{cmp_fallback, Compare},
+    CleanResponse, Empty, TestCase, TestResult,
+};
 
 impl Empty for WorkspaceEdit {}
 
@@ -60,7 +69,536 @@ pub struct RenameMismatchError {
 impl std::fmt::Display for RenameMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Rename response:", self.test_id)?;
-        write_fields_comparison(f, "WorkspaceEdit", &self.expected, &self.actual, 0)?;
+        WorkspaceEdit::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for WorkspaceEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}WorkspaceEdit {{")?;
+        <Option<HashMap<Uri, Vec<TextEdit>>>>::compare(
+            f,
+            Some("changes"),
+            &expected.changes,
+            &actual.changes,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<DocumentChanges>>::compare(
+            f,
+            Some("document_changes"),
+            &expected.document_changes,
+            &actual.document_changes,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for OptionalVersionedTextDocumentIdentifier {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}OptionalTextDocumentIdentifier {{")?;
+        Uri::compare(
+            f,
+            Some("uri"),
+            &expected.uri,
+            &actual.uri,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<i32>>::compare(
+            f,
+            Some("version"),
+            &expected.version,
+            &actual.version,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl<T, U> Compare for OneOf<T, U>
+where
+    T: Compare + PartialEq + std::fmt::Debug,
+    U: Compare + PartialEq + std::fmt::Debug,
+{
+    type Nested1 = T;
+    type Nested2 = U;
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Left(expected), Self::Left(actual)) => {
+                writeln!(f, "{padding}{name_str}OneOf::A (")?;
+                T::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Right(expected), Self::Right(actual)) => {
+                writeln!(f, "{padding}{name_str}OneOf::B (")?;
+                U::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for TextDocumentEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}TextDocumentEdit {{")?;
+        OptionalVersionedTextDocumentIdentifier::compare(
+            f,
+            Some("text_document"),
+            &expected.text_document,
+            &actual.text_document,
+            depth + 1,
+            override_color,
+        )?;
+        <Vec<OneOf<TextEdit, AnnotatedTextEdit>>>::compare(
+            f,
+            Some("edits"),
+            &expected.edits,
+            &actual.edits,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CreateFileOptions {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CreateFileOptions {{")?;
+        <Option<bool>>::compare(
+            f,
+            Some("overwrite"),
+            &expected.overwrite,
+            &actual.overwrite,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("ignore_if_exists"),
+            &expected.ignore_if_exists,
+            &actual.ignore_if_exists,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for CreateFile {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}CreateFile {{")?;
+        Uri::compare(
+            f,
+            Some("uri"),
+            &expected.uri,
+            &actual.uri,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<CreateFileOptions>>::compare(
+            f,
+            Some("options"),
+            &expected.options,
+            &actual.options,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<ChangeAnnotationIdentifier>>::compare(
+            f,
+            Some("annotation_id"),
+            &expected.annotation_id,
+            &actual.annotation_id,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for RenameFileOptions {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}RenameFileOptions {{")?;
+        <Option<bool>>::compare(
+            f,
+            Some("overwrite"),
+            &expected.overwrite,
+            &actual.overwrite,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("ignore_if_exists"),
+            &expected.ignore_if_exists,
+            &actual.ignore_if_exists,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for RenameFile {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}RenameFile {{")?;
+        Uri::compare(
+            f,
+            Some("old_uri"),
+            &expected.old_uri,
+            &actual.old_uri,
+            depth + 1,
+            override_color,
+        )?;
+        Uri::compare(
+            f,
+            Some("new_uri"),
+            &expected.new_uri,
+            &actual.new_uri,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<RenameFileOptions>>::compare(
+            f,
+            Some("options"),
+            &expected.options,
+            &actual.options,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<ChangeAnnotationIdentifier>>::compare(
+            f,
+            Some("annotation_id"),
+            &expected.annotation_id,
+            &actual.annotation_id,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for DeleteFileOptions {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}DeleteFileOptions {{")?;
+        <Option<bool>>::compare(
+            f,
+            Some("recursive"),
+            &expected.recursive,
+            &actual.recursive,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("ignore_if_not_exists"),
+            &expected.ignore_if_not_exists,
+            &actual.ignore_if_not_exists,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<ChangeAnnotationIdentifier>>::compare(
+            f,
+            Some("annotation_id"),
+            &expected.annotation_id,
+            &actual.annotation_id,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for DeleteFile {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}DeleteFile {{")?;
+        Uri::compare(
+            f,
+            Some("uri"),
+            &expected.uri,
+            &actual.uri,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<DeleteFileOptions>>::compare(
+            f,
+            Some("options"),
+            &expected.options,
+            &actual.options,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for ResourceOp {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Create(expected_create), Self::Create(actual_create)) => {
+                writeln!(f, "{padding}{name_str}ResourceOp::Create (")?;
+                CreateFile::compare(
+                    f,
+                    None,
+                    expected_create,
+                    actual_create,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Rename(expected_rename), Self::Rename(actual_rename)) => {
+                writeln!(f, "{padding}{name_str}ResourceOp::Rename (")?;
+                RenameFile::compare(
+                    f,
+                    Some("old_uri"),
+                    expected_rename,
+                    actual_rename,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Delete(expected_delete), Self::Delete(actual_delete)) => {
+                writeln!(f, "{padding}{name_str}ResourceOp::Delete (")?;
+                DeleteFile::compare(
+                    f,
+                    None,
+                    expected_delete,
+                    actual_delete,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for DocumentChangeOperation {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Op(expected_op), Self::Op(actual_op)) => {
+                writeln!(f, "{padding}{name_str}DocumentChangeOperation::Op (")?;
+                ResourceOp::compare(f, None, expected_op, actual_op, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Edit(expected_edit), Self::Edit(actual_edit)) => {
+                writeln!(f, "{padding}{name_str}DocumentChangeOperation::Edit (")?;
+                TextDocumentEdit::compare(
+                    f,
+                    None,
+                    expected_edit,
+                    actual_edit,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for DocumentChanges {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Edits(expected_edits), Self::Edits(actual_edits)) => {
+                writeln!(f, "{padding}{name_str}DocumentChanges::Edits (")?;
+                <Vec<TextDocumentEdit>>::compare(
+                    f,
+                    None,
+                    expected_edits,
+                    actual_edits,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Operations(expected_ops), Self::Operations(actual_ops)) => {
+                writeln!(f, "{padding}{name_str}DocumentChanges::Operations (")?;
+                <Vec<DocumentChangeOperation>>::compare(
+                    f,
+                    None,
+                    expected_ops,
+                    actual_ops,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
         Ok(())
     }
 }

--- a/lspresso-shot/types/rename.rs
+++ b/lspresso-shot/types/rename.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+
+use lsp_types::{DocumentChangeOperation, DocumentChanges, ResourceOp, WorkspaceEdit};
+use thiserror::Error;
+
+use super::{clean_uri, write_fields_comparison, CleanResponse, Empty, TestCase, TestResult};
+
+impl Empty for WorkspaceEdit {}
+
+impl CleanResponse for WorkspaceEdit {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        if let Some(ref mut changes) = self.changes {
+            let mut new_changes = HashMap::new();
+            for (uri, edits) in changes.drain() {
+                let cleaned_uri = clean_uri(&uri, test_case)?;
+                new_changes.insert(cleaned_uri, edits);
+            }
+            *changes = new_changes;
+        }
+        match self.document_changes {
+            Some(DocumentChanges::Edits(ref mut edits)) => {
+                for edit in edits {
+                    edit.text_document.uri = clean_uri(&edit.text_document.uri, test_case)?;
+                }
+            }
+            Some(DocumentChanges::Operations(ref mut ops)) => {
+                for op in ops {
+                    match op {
+                        DocumentChangeOperation::Op(ref mut op) => match op {
+                            ResourceOp::Create(ref mut create) => {
+                                create.uri = clean_uri(&create.uri, test_case)?;
+                            }
+                            ResourceOp::Rename(ref mut rename) => {
+                                rename.old_uri = clean_uri(&rename.old_uri, test_case)?;
+                                rename.new_uri = clean_uri(&rename.new_uri, test_case)?;
+                            }
+                            ResourceOp::Delete(ref mut delete) => {
+                                delete.uri = clean_uri(&delete.uri, test_case)?;
+                            }
+                        },
+                        DocumentChangeOperation::Edit(edit) => {
+                            edit.text_document.uri = clean_uri(&edit.text_document.uri, test_case)?;
+                        }
+                    }
+                }
+            }
+            None => {}
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct RenameMismatchError {
+    pub test_id: String,
+    pub expected: WorkspaceEdit,
+    pub actual: WorkspaceEdit,
+}
+
+impl std::fmt::Display for RenameMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect Rename response:", self.test_id)?;
+        write_fields_comparison(f, "WorkspaceEdit", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/selection_range.rs
+++ b/lspresso-shot/types/selection_range.rs
@@ -1,7 +1,7 @@
-use lsp_types::SelectionRange;
+use lsp_types::{Range, SelectionRange};
 use thiserror::Error;
 
-use super::{write_fields_comparison, CleanResponse, Empty};
+use super::{compare::Compare, CleanResponse, Empty};
 
 impl Empty for Vec<SelectionRange> {}
 
@@ -21,7 +21,59 @@ impl std::fmt::Display for SelectionRangeMismatchError {
             "Test {}: Incorrect Selection Range response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Selection Range", &self.expected, &self.actual, 0)?;
+        <Vec<SelectionRange>>::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for SelectionRange {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SelectionRange {{")?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        Option::<Box<Self>>::compare(
+            f,
+            Some("parent"),
+            &expected.parent,
+            &actual.parent,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
+    }
+}
+
+impl Compare for Box<SelectionRange> {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let expected = *(expected.clone());
+        let actual = *(actual.clone());
+        SelectionRange::compare(f, name, &expected, &actual, depth, override_color)
     }
 }

--- a/lspresso-shot/types/selection_range.rs
+++ b/lspresso-shot/types/selection_range.rs
@@ -1,0 +1,27 @@
+use lsp_types::SelectionRange;
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for Vec<SelectionRange> {}
+
+impl CleanResponse for Vec<SelectionRange> {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct SelectionRangeMismatchError {
+    pub test_id: String,
+    pub expected: Vec<SelectionRange>,
+    pub actual: Vec<SelectionRange>,
+}
+
+impl std::fmt::Display for SelectionRangeMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Selection Range response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Selection Range", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/semantic_tokens.rs
+++ b/lspresso-shot/types/semantic_tokens.rs
@@ -1,7 +1,14 @@
-use lsp_types::{SemanticTokensFullDeltaResult, SemanticTokensRangeResult, SemanticTokensResult};
+use lsp_types::{
+    SemanticToken, SemanticTokens, SemanticTokensDelta, SemanticTokensEdit,
+    SemanticTokensFullDeltaResult, SemanticTokensPartialResult, SemanticTokensRangeResult,
+    SemanticTokensResult,
+};
 use thiserror::Error;
 
-use super::{write_fields_comparison, CleanResponse, Empty};
+use super::{
+    compare::{cmp_fallback, Compare},
+    CleanResponse, Empty,
+};
 
 impl Empty for SemanticTokensResult {}
 impl Empty for SemanticTokensFullDeltaResult {}
@@ -25,8 +32,7 @@ impl std::fmt::Display for SemanticTokensFullMismatchError {
             "Test {}: Incorrect Semantic Tokens Full response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Semantic Tokens", &self.expected, &self.actual, 0)?;
-        Ok(())
+        SemanticTokensResult::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }
 
@@ -44,14 +50,7 @@ impl std::fmt::Display for SemanticTokensFullDeltaMismatchError {
             "Test {}: Incorrect Semantic Tokens Full Delta response:",
             self.test_id
         )?;
-        write_fields_comparison(
-            f,
-            "Semantic Tokens Full Delta",
-            &self.expected,
-            &self.actual,
-            0,
-        )?;
-        Ok(())
+        SemanticTokensFullDeltaResult::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }
 
@@ -69,7 +68,374 @@ impl std::fmt::Display for SemanticTokensRangeMismatchError {
             "Test {}: Incorrect Semantic Tokens Range response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "Semantic Tokens", &self.expected, &self.actual, 0)?;
+        SemanticTokensRangeResult::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for SemanticTokensRangeResult {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Tokens(expected_tokens), Self::Tokens(actual_tokens)) => {
+                writeln!(f, "{padding}{name_str}SemanticTokensRangeResult::Tokens (")?;
+                SemanticTokens::compare(
+                    f,
+                    None,
+                    expected_tokens,
+                    actual_tokens,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Partial(expected_partial_result), Self::Partial(actual_partial_result)) => {
+                writeln!(f, "{padding}{name_str}SemanticTokensRangeResult::Tokens (")?;
+                SemanticTokensPartialResult::compare(
+                    f,
+                    None,
+                    expected_partial_result,
+                    actual_partial_result,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        writeln!(f, "{padding})")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticTokensFullDeltaResult {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Tokens(expected_tokens), Self::Tokens(actual_tokens)) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}SemanticTokensFullDeltaResult::Tokens ("
+                )?;
+                SemanticTokens::compare(
+                    f,
+                    name,
+                    expected_tokens,
+                    actual_tokens,
+                    depth,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::TokensDelta(expected_delta), Self::TokensDelta(actual_delta)) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}SemanticTokensFullDeltaResult::TokensDelta ("
+                )?;
+                SemanticTokensDelta::compare(
+                    f,
+                    name,
+                    expected_delta,
+                    actual_delta,
+                    depth,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (
+                Self::PartialTokensDelta {
+                    edits: expected_edits,
+                },
+                Self::PartialTokensDelta {
+                    edits: actual_edits,
+                },
+            ) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}SemanticTokensFullDeltaResult::PartialTokensDelta ("
+                )?;
+                <Vec<SemanticTokensEdit>>::compare(
+                    f,
+                    name,
+                    expected_edits,
+                    actual_edits,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticTokensDelta {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SemanticTokensDelta {{")?;
+        <Option<String>>::compare(
+            f,
+            Some("result_id"),
+            &expected.result_id,
+            &actual.result_id,
+            depth + 1,
+            override_color,
+        )?;
+        <Vec<SemanticTokensEdit>>::compare(
+            f,
+            Some("edits"),
+            &expected.edits,
+            &actual.edits,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticTokensResult {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Tokens(expected_tokens), Self::Tokens(actual_tokens)) => {
+                writeln!(f, "{padding}{name_str}SemanticTokensResult::Tokens (")?;
+                SemanticTokens::compare(
+                    f,
+                    None,
+                    expected_tokens,
+                    actual_tokens,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Partial(expected_full), Self::Partial(actual_full)) => {
+                writeln!(f, "{padding}{name_str}SemanticTokensResult::Partial (")?;
+                SemanticTokensPartialResult::compare(
+                    f,
+                    None,
+                    expected_full,
+                    actual_full,
+                    depth + 1,
+                    override_color,
+                )?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        writeln!(f, "{padding})")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticToken {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SemanticToken {{")?;
+        u32::compare(
+            f,
+            Some("delta_line"),
+            &expected.delta_line,
+            &actual.delta_line,
+            depth + 1,
+            override_color,
+        )?;
+        u32::compare(
+            f,
+            Some("delta_start"),
+            &expected.delta_start,
+            &actual.delta_start,
+            depth + 1,
+            override_color,
+        )?;
+        u32::compare(
+            f,
+            Some("length"),
+            &expected.length,
+            &actual.length,
+            depth + 1,
+            override_color,
+        )?;
+        u32::compare(
+            f,
+            Some("token_type"),
+            &expected.token_type,
+            &actual.token_type,
+            depth + 1,
+            override_color,
+        )?;
+        u32::compare(
+            f,
+            Some("token_modifiers_bitset"),
+            &expected.token_modifiers_bitset,
+            &actual.token_modifiers_bitset,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticTokensEdit {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SemanticTokensEdit {{")?;
+        u32::compare(
+            f,
+            Some("start"),
+            &expected.start,
+            &actual.start,
+            depth + 1,
+            override_color,
+        )?;
+        u32::compare(
+            f,
+            Some("delete_count"),
+            &expected.delete_count,
+            &actual.delete_count,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<SemanticToken>>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticTokensPartialResult {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SemanticTokensPartialResult {{")?;
+        <Vec<SemanticToken>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for SemanticTokens {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}SemanticTokens {{")?;
+        <Option<String>>::compare(
+            f,
+            Some("result_id"),
+            &expected.result_id,
+            &actual.result_id,
+            depth + 1,
+            override_color,
+        )?;
+        <Vec<SemanticToken>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
         Ok(())
     }
 }

--- a/lspresso-shot/types/semantic_tokens.rs
+++ b/lspresso-shot/types/semantic_tokens.rs
@@ -1,0 +1,75 @@
+use lsp_types::{SemanticTokensFullDeltaResult, SemanticTokensRangeResult, SemanticTokensResult};
+use thiserror::Error;
+
+use super::{write_fields_comparison, CleanResponse, Empty};
+
+impl Empty for SemanticTokensResult {}
+impl Empty for SemanticTokensFullDeltaResult {}
+impl Empty for SemanticTokensRangeResult {}
+
+impl CleanResponse for SemanticTokensResult {}
+impl CleanResponse for SemanticTokensFullDeltaResult {}
+impl CleanResponse for SemanticTokensRangeResult {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct SemanticTokensFullMismatchError {
+    pub test_id: String,
+    pub expected: SemanticTokensResult,
+    pub actual: SemanticTokensResult,
+}
+
+impl std::fmt::Display for SemanticTokensFullMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Semantic Tokens Full response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Semantic Tokens", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct SemanticTokensFullDeltaMismatchError {
+    pub test_id: String,
+    pub expected: SemanticTokensFullDeltaResult,
+    pub actual: SemanticTokensFullDeltaResult,
+}
+
+impl std::fmt::Display for SemanticTokensFullDeltaMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Semantic Tokens Full Delta response:",
+            self.test_id
+        )?;
+        write_fields_comparison(
+            f,
+            "Semantic Tokens Full Delta",
+            &self.expected,
+            &self.actual,
+            0,
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct SemanticTokensRangeMismatchError {
+    pub test_id: String,
+    pub expected: SemanticTokensRangeResult,
+    pub actual: SemanticTokensRangeResult,
+}
+
+impl std::fmt::Display for SemanticTokensRangeMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Semantic Tokens Range response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Semantic Tokens", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/type_definition.rs
+++ b/lspresso-shot/types/type_definition.rs
@@ -1,13 +1,145 @@
-use lsp_types::request::GotoTypeDefinitionResponse;
+use lsp_types::{request::GotoTypeDefinitionResponse, Location, LocationLink, Range, Uri};
 use thiserror::Error;
 
-use super::write_fields_comparison;
+use super::compare::{cmp_fallback, Compare};
 
 #[derive(Debug, Error, PartialEq)]
 pub struct TypeDefinitionMismatchError {
     pub test_id: String,
     pub expected: GotoTypeDefinitionResponse,
     pub actual: GotoTypeDefinitionResponse,
+}
+
+impl Compare for Location {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str} Location {{")?;
+        Uri::compare(
+            f,
+            Some("uri"),
+            &expected.uri,
+            &actual.uri,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("range"),
+            &expected.range,
+            &actual.range,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for LocationLink {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str} LocationLink {{")?;
+        Option::<Range>::compare(
+            f,
+            Some("origin_selection_range"),
+            &expected.origin_selection_range,
+            &actual.origin_selection_range,
+            depth + 1,
+            override_color,
+        )?;
+        Uri::compare(
+            f,
+            Some("target_uri"),
+            &expected.target_uri,
+            &actual.target_uri,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("target_range"),
+            &expected.target_range,
+            &actual.target_range,
+            depth + 1,
+            override_color,
+        )?;
+        Range::compare(
+            f,
+            Some("target_selection_range"),
+            &expected.target_selection_range,
+            &actual.target_selection_range,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for GotoTypeDefinitionResponse {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Scalar(expected_loc), Self::Scalar(actual_loc)) => {
+                writeln!(f, "{padding}{name_str}GotoTypeDefinitionResponse::Scalar (")?;
+                Location::compare(f, None, expected_loc, actual_loc, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Array(expected_arr), Self::Array(actual_arr)) => {
+                writeln!(f, "{padding}{name_str}GotoTypeDefinitionResponse::Array (")?;
+                Vec::compare(f, None, expected_arr, actual_arr, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Link(expected_links), Self::Link(actual_links)) => {
+                writeln!(f, "{padding}{name_str}GotoTypeDefinitionResponse::Link (")?;
+                Vec::compare(
+                    f,
+                    None,
+                    expected_links,
+                    actual_links,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        writeln!(f, "{padding})")?;
+
+        Ok(())
+    }
 }
 
 impl std::fmt::Display for TypeDefinitionMismatchError {
@@ -17,7 +149,6 @@ impl std::fmt::Display for TypeDefinitionMismatchError {
             "Test {}: Incorrect GotoTypeDefinition response:",
             self.test_id
         )?;
-        write_fields_comparison(f, "GotoTypeDefinition", &self.expected, &self.actual, 0)?;
-        Ok(())
+        GotoTypeDefinitionResponse::compare(f, None, &self.expected, &self.actual, 0, None)
     }
 }

--- a/lspresso-shot/types/type_definition.rs
+++ b/lspresso-shot/types/type_definition.rs
@@ -1,0 +1,23 @@
+use lsp_types::request::GotoTypeDefinitionResponse;
+use thiserror::Error;
+
+use super::write_fields_comparison;
+
+#[derive(Debug, Error, PartialEq)]
+pub struct TypeDefinitionMismatchError {
+    pub test_id: String,
+    pub expected: GotoTypeDefinitionResponse,
+    pub actual: GotoTypeDefinitionResponse,
+}
+
+impl std::fmt::Display for TypeDefinitionMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect GotoTypeDefinition response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "GotoTypeDefinition", &self.expected, &self.actual, 0)?;
+        Ok(())
+    }
+}

--- a/test-suite/src/completion.rs
+++ b/test-suite/src/completion.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_completion,
-        types::{CompletionResult, ServerStartType, TestCase, TestError, TestFile},
+        types::{completion::CompletionResult, ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 

--- a/test-suite/src/formatting.rs
+++ b/test-suite/src/formatting.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_formatting,
-        types::{FormattingResult, ServerStartType, TestCase, TestError, TestFile},
+        types::{formatting::FormattingResult, ServerStartType, TestCase, TestError, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 

--- a/test-suite/src/semantic_tokens_full.rs
+++ b/test-suite/src/semantic_tokens_full.rs
@@ -5,7 +5,10 @@ mod test {
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
         lspresso_shot, test_semantic_tokens_full,
-        types::{SemanticTokensFullMismatchError, ServerStartType, TestCase, TestError, TestFile},
+        types::{
+            semantic_tokens::SemanticTokensFullMismatchError, ServerStartType, TestCase, TestError,
+            TestFile,
+        },
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 


### PR DESCRIPTION
This ended up being a lot...

- The first commit just splits up `types.rs` into multiple files. This is mostly based on test type, but also groups a few related requests (i.e. incoming and outgoing calls) together.

- The second commit is a bit unfortunate. My initial solution to this was a lot simpler:

Since the LSP protocol is defined to use JSON RPC, every single LSP type implements `serde`'s `Serialize` trait. Given this, to compare two structs field by field, we just convert each to their `serde_json::Value` representation and iterate through. Simple enough...except every single optional field in the `lsp_types` crate uses:
```rust
#[serde(skip_serializing_if = "Option::is_none")]
```

This becomes an issue when comparing certain types. For example, we have the following (stripped down) type definitions from `lsp_types`:

```rust
pub struct SemanticTokens {
    #[serde(skip_serializing_if = "Option::is_none")]
    pub result_id: Option<String>,
    pub data: Vec<SemanticToken>,
}

pub struct SemanticTokensPartialResult {
    pub data: Vec<SemanticToken>,
}

pub enum SemanticTokensResult {
    Tokens(SemanticTokens),
    Partial(SemanticTokensPartialResult),
}
```

You may note that when `result_id == None`, `SemanticTokens` and `SemanticTokensPartialResult` are structurally identical, and *completely indistinguishable* in their JSON representations:

```json
{
    "data": [ ],
}
```

This led to really poor error messages, where the library would say the expected and actual results don't match, but in the struct diff every (visible) field would match. To fix this, I've added a `Compare` trait. This adds ~~a bit~~ a *lot* of boilerplate, but I'd rather have a messy but correct implementation in this case. I have a very strong feeling that there's a much better way to implement this, but my macro-fu isn't quite there (yet). I'm going to continue tinkering with this problem, but for now this will do. 

Moving forward, I'd like to do the following:
- Work on cutting down redundant Lua code
- Implement the rest of the request method types
- Work on adding benchmarking capabilities to the lib
- Wrap all existing functionality into CLI tool, enabling its use for non-Rust LSPs