### PR TITLE
feat(lib): `textDocument/diagnostic`

### DIFF
--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -45,6 +45,7 @@ pub fn get_init_dot_lua(
         | TestType::CompletionResolve
         | TestType::Declaration
         | TestType::Definition
+        | TestType::Diagnostic
         | TestType::DocumentHighlight
         | TestType::DocumentLink
         | TestType::DocumentLinkResolve
@@ -122,6 +123,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::CompletionResolve => include_str!("lua_templates/completion_resolve_action.lua"),
         TestType::Declaration => include_str!("lua_templates/declaration_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),
+        TestType::Diagnostic => include_str!("lua_templates/diagnostic_action.lua"),
         TestType::DocumentHighlight => include_str!("lua_templates/document_highlight_action.lua"),
         TestType::DocumentLink => include_str!("lua_templates/document_link_action.lua"),
         TestType::DocumentLinkResolve => include_str!("lua_templates/document_link_resolve_action.lua"),

--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -66,7 +66,7 @@ pub fn get_init_dot_lua(
         | TestType::TypeDefinition => {
             raw_init = raw_init.replace("LSP_ACTION", &invoke_lsp_action(&test_case.start_type));
         }
-        TestType::Diagnostic => {
+        TestType::PublishDiagnostics => {
             // Diagnostics are handled via an autocmd, no need to handle `$/progress`
             raw_init = raw_init.replace("LSP_ACTION", "");
             raw_init.push_str(include_str!("lua_templates/diagnostic_autocmd.lua"));
@@ -122,7 +122,6 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::CompletionResolve => include_str!("lua_templates/completion_resolve_action.lua"),
         TestType::Declaration => include_str!("lua_templates/declaration_action.lua"),
         TestType::Definition => include_str!("lua_templates/definition_action.lua"),
-        TestType::Diagnostic => "\n-- NOTE: No `check_progress_result` function for diagnostics, instead handled by `DiagnosticChanged` autocmd\n",
         TestType::DocumentHighlight => include_str!("lua_templates/document_highlight_action.lua"),
         TestType::DocumentLink => include_str!("lua_templates/document_link_action.lua"),
         TestType::DocumentLinkResolve => include_str!("lua_templates/document_link_resolve_action.lua"),
@@ -135,6 +134,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::Moniker => include_str!("lua_templates/moniker_action.lua"),
         TestType::OutgoingCalls => include_str!("lua_templates/outgoing_calls_action.lua"),
         TestType::PrepareCallHierarchy => include_str!("lua_templates/prepare_call_hierarchy_action.lua"),
+        TestType::PublishDiagnostics => "\n-- NOTE: No `check_progress_result` function for diagnostics, instead handled by `DiagnosticChanged` autocmd\n",
         TestType::References => include_str!("lua_templates/references_action.lua"),
         TestType::Rename => include_str!("lua_templates/rename_action.lua"),
         TestType::SelectionRange => include_str!("lua_templates/selection_range_action.lua"),

--- a/lspresso-shot/lua_templates/diagnostic_action.lua
+++ b/lspresso-shot/lua_templates/diagnostic_action.lua
@@ -1,0 +1,45 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    local identifier_json = [[
+    IDENTIFIER
+]]
+    local previous_result_id_json = [[
+    PREVIOUS_RESULT_ID
+]]
+    local identifier = vim.json.decode(identifier_json)
+    local previous_result_id = vim.json.decode(previous_result_id_json)
+    report_log('Identifier: ' .. vim.inspect(identifier) .. '\n') ---@diagnostic disable-line: undefined-global
+    report_log('Previous Result ID: ' .. vim.inspect(previous_result_id) .. '\n') ---@diagnostic disable-line: undefined-global
+    report_log('Issuing diagnostic request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local diagnostic_result = vim.lsp.buf_request_sync(0, 'textDocument/diagnostic', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        identifier = identifier,
+        previousResultId = previous_result_id,
+    })
+
+    if not diagnostic_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid diagnostic result returned: ' .. vim.inspect(diagnostic_result) .. '\n')
+    elseif diagnostic_result and #diagnostic_result >= 1 and diagnostic_result[1].result then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            exit() ---@diagnostic disable-line: undefined-global
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(diagnostic_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    exit() ---@diagnostic disable-line: undefined-global
+end

--- a/lspresso-shot/types/diagnostic.rs
+++ b/lspresso-shot/types/diagnostic.rs
@@ -26,13 +26,13 @@ impl CleanResponse for Vec<Diagnostic> {
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
-pub struct DiagnosticMismatchError {
+pub struct PublishDiagnosticsMismatchError {
     pub test_id: String,
     pub expected: Vec<Diagnostic>,
     pub actual: Vec<Diagnostic>,
 }
 
-impl std::fmt::Display for DiagnosticMismatchError {
+impl std::fmt::Display for PublishDiagnosticsMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Test {}: Incorrect Diagnostic response:", self.test_id)?;
         <Vec<Diagnostic>>::compare(f, None, &self.expected, &self.actual, 0, None)

--- a/lspresso-shot/types/diagnostic.rs
+++ b/lspresso-shot/types/diagnostic.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
+
 use lsp_types::{
     CodeDescription, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag,
-    Location, NumberOrString, Range, Uri,
+    DocumentDiagnosticReport, DocumentDiagnosticReportKind, FullDocumentDiagnosticReport, Location,
+    NumberOrString, Range, RelatedFullDocumentDiagnosticReport,
+    RelatedUnchangedDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport, Uri,
 };
 use thiserror::Error;
 
@@ -11,6 +15,7 @@ use super::{
 };
 
 impl Empty for Vec<Diagnostic> {}
+impl Empty for DocumentDiagnosticReport {}
 
 impl CleanResponse for Vec<Diagnostic> {
     fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
@@ -25,6 +30,37 @@ impl CleanResponse for Vec<Diagnostic> {
     }
 }
 
+impl CleanResponse for DocumentDiagnosticReportKind {}
+
+impl CleanResponse for DocumentDiagnosticReport {
+    fn clean_response(mut self, test_case: &TestCase) -> TestResult<Self> {
+        match &mut self {
+            Self::Full(report) => {
+                if let Some(ref mut related_documents) = report.related_documents {
+                    let mut cleaned_map = HashMap::new();
+                    for (uri, kind) in related_documents.drain() {
+                        let cleaned_uri = clean_uri(&uri, test_case)?;
+                        cleaned_map.insert(cleaned_uri, kind);
+                    }
+                    *related_documents = cleaned_map;
+                }
+            }
+            Self::Unchanged(report) => {
+                if let Some(ref mut related_documents) = report.related_documents {
+                    let mut cleaned_map = HashMap::new();
+                    for (uri, kind) in related_documents.drain() {
+                        let cleaned_uri = clean_uri(&uri, test_case)?;
+                        cleaned_map.insert(cleaned_uri, kind);
+                    }
+                    *related_documents = cleaned_map;
+                }
+            }
+        }
+
+        Ok(self)
+    }
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub struct PublishDiagnosticsMismatchError {
     pub test_id: String,
@@ -34,8 +70,251 @@ pub struct PublishDiagnosticsMismatchError {
 
 impl std::fmt::Display for PublishDiagnosticsMismatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Test {}: Incorrect Diagnostic response:", self.test_id)?;
+        writeln!(
+            f,
+            "Test {}: Incorrect Publish Diagnostics response:",
+            self.test_id
+        )?;
         <Vec<Diagnostic>>::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub struct DiagnosticMismatchError {
+    pub test_id: String,
+    pub expected: DocumentDiagnosticReport,
+    pub actual: DocumentDiagnosticReport,
+}
+
+impl std::fmt::Display for DiagnosticMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect Diagnostic response:", self.test_id)?;
+        DocumentDiagnosticReport::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for DocumentDiagnosticReport {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        match (expected, actual) {
+            (Self::Full(expected_full), Self::Full(actual_full)) => {
+                RelatedFullDocumentDiagnosticReport::compare(
+                    f,
+                    name,
+                    expected_full,
+                    actual_full,
+                    depth,
+                    override_color,
+                )?;
+            }
+            (Self::Unchanged(expected_unchanged), Self::Unchanged(actual_unchanged)) => {
+                RelatedUnchangedDocumentDiagnosticReport::compare(
+                    f,
+                    name,
+                    expected_unchanged,
+                    actual_unchanged,
+                    depth,
+                    override_color,
+                )?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        Ok(())
+    }
+}
+
+impl Compare for RelatedUnchangedDocumentDiagnosticReport {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(
+            f,
+            "{padding}{name_str}RelatedUnchangedDocumentDiagnosticReport {{"
+        )?;
+        <Option<HashMap<Uri, DocumentDiagnosticReportKind>>>::compare(
+            f,
+            Some("related_documents"),
+            &expected.related_documents,
+            &actual.related_documents,
+            depth + 1,
+            override_color,
+        )?;
+        UnchangedDocumentDiagnosticReport::compare(
+            f,
+            Some("unchanged_document_diagnostic_report"),
+            &expected.unchanged_document_diagnostic_report,
+            &actual.unchanged_document_diagnostic_report,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+        Ok(())
+    }
+}
+
+impl Compare for RelatedFullDocumentDiagnosticReport {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(
+            f,
+            "{padding}{name_str}RelatedFullDocumentDiagnosticReport {{"
+        )?;
+        <Option<HashMap<Uri, DocumentDiagnosticReportKind>>>::compare(
+            f,
+            Some("related_documents"),
+            &expected.related_documents,
+            &actual.related_documents,
+            depth + 1,
+            override_color,
+        )?;
+        FullDocumentDiagnosticReport::compare(
+            f,
+            Some("report"),
+            &expected.full_document_diagnostic_report,
+            &actual.full_document_diagnostic_report,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for DocumentDiagnosticReportKind {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::Full(expected_full), Self::Full(actual_full)) => {
+                writeln!(f, "{padding}{name_str}DocumentDiagnosticReportKind::Full (")?;
+                FullDocumentDiagnosticReport::compare(
+                    f,
+                    name,
+                    expected_full,
+                    actual_full,
+                    depth,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::Unchanged(expected_unchanged), Self::Unchanged(actual_unchanged)) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}DocumentDiagnosticReportKind::Unchanged ("
+                )?;
+                UnchangedDocumentDiagnosticReport::compare(
+                    f,
+                    name,
+                    expected_unchanged,
+                    actual_unchanged,
+                    depth,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        Ok(())
+    }
+}
+
+impl Compare for UnchangedDocumentDiagnosticReport {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}UnchangedDocumentDiagnosticReport {{")?;
+        String::compare(
+            f,
+            Some("result_id"),
+            &expected.result_id,
+            &actual.result_id,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+        Ok(())
+    }
+}
+
+impl Compare for FullDocumentDiagnosticReport {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}FullDocumentDiagnosticReport {{")?;
+        <Option<String>>::compare(
+            f,
+            Some("result_id"),
+            &expected.result_id,
+            &actual.result_id,
+            depth + 1,
+            override_color,
+        )?;
+        <Vec<Diagnostic>>::compare(
+            f,
+            Some("items"),
+            &expected.items,
+            &actual.items,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
     }
 }
 

--- a/lspresso-shot/types/mod.rs
+++ b/lspresso-shot/types/mod.rs
@@ -28,7 +28,7 @@ use crate::types::{
     completion::CompletionMismatchError,
     declaration::DeclarationMismatchError,
     definition::DefinitionMismatchError,
-    diagnostic::DiagnosticMismatchError,
+    diagnostic::PublishDiagnosticsMismatchError,
     document_highlight::DocumentHighlightMismatchError,
     document_link::{DocumentLinkMismatchError, DocumentLinkResolveMismatchError},
     document_symbol::DocumentSymbolMismatchError,
@@ -77,8 +77,6 @@ pub enum TestType {
     Declaration,
     /// Test `textDocument/definition` requests
     Definition,
-    /// Test `textDocument/publishDiagnostics` requests
-    Diagnostic,
     /// Test `textDocument/documentHighlight` requests
     DocumentHighlight,
     /// Test `textDocument/documentLink` requests
@@ -103,6 +101,8 @@ pub enum TestType {
     OutgoingCalls,
     /// Test `textDocument/prepareCallHierarchy` requests
     PrepareCallHierarchy,
+    /// Test `textDocument/publishDiagnostics` requests
+    PublishDiagnostics,
     /// Test `textDocument/references` requests
     References,
     /// Test `textDocument/rename` requests
@@ -131,7 +131,6 @@ impl std::fmt::Display for TestType {
                 Self::CompletionResolve => "completionItem/resolve",
                 Self::Declaration => "textDocument/declaration",
                 Self::Definition => "textDocument/definition",
-                Self::Diagnostic => "textDocument/publishDiagnostics",
                 Self::DocumentHighlight => "textDocument/documentHighlight",
                 Self::DocumentLink => "textDocument/documentLink",
                 Self::DocumentLinkResolve => "documentLink/resolve",
@@ -144,6 +143,7 @@ impl std::fmt::Display for TestType {
                 Self::Moniker => "textDocument/moniker",
                 Self::OutgoingCalls => "callHierarchy/outgoingCalls",
                 Self::PrepareCallHierarchy => "textDocument/prepareCallHierarchy",
+                Self::PublishDiagnostics => "textDocument/publishDiagnostics",
                 Self::References => "textDocument/references",
                 Self::Rename => "textDocument/rename",
                 Self::SelectionRange => "textDocument/selectionRange",
@@ -618,7 +618,7 @@ pub enum TestError {
     #[error(transparent)]
     DefinitionMismatch(#[from] Box<DefinitionMismatchError>),
     #[error(transparent)]
-    DiagnosticMismatch(#[from] DiagnosticMismatchError),
+    PublishDiagnosticsMismatch(#[from] PublishDiagnosticsMismatchError),
     #[error(transparent)]
     DocumentHighlightMismatch(#[from] DocumentHighlightMismatchError),
     #[error(transparent)]

--- a/lspresso-shot/types/mod.rs
+++ b/lspresso-shot/types/mod.rs
@@ -56,6 +56,7 @@ use std::{
 };
 
 use completion::CompletionResolveMismatchError;
+use diagnostic::DiagnosticMismatchError;
 use lsp_types::{Position, Uri};
 use moniker::MonikerMismatchError;
 use rand::distr::Distribution as _;
@@ -77,6 +78,8 @@ pub enum TestType {
     Declaration,
     /// Test `textDocument/definition` requests
     Definition,
+    /// Test 'textDocument/diagnostic' requests
+    Diagnostic,
     /// Test `textDocument/documentHighlight` requests
     DocumentHighlight,
     /// Test `textDocument/documentLink` requests
@@ -131,6 +134,7 @@ impl std::fmt::Display for TestType {
                 Self::CompletionResolve => "completionItem/resolve",
                 Self::Declaration => "textDocument/declaration",
                 Self::Definition => "textDocument/definition",
+                Self::Diagnostic => "textDocument/diagnostic",
                 Self::DocumentHighlight => "textDocument/documentHighlight",
                 Self::DocumentLink => "textDocument/documentLink",
                 Self::DocumentLinkResolve => "documentLink/resolve",
@@ -617,6 +621,8 @@ pub enum TestError {
     DeclarationMismatch(#[from] Box<DeclarationMismatchError>),
     #[error(transparent)]
     DefinitionMismatch(#[from] Box<DefinitionMismatchError>),
+    #[error(transparent)]
+    DiagnosticMismatch(#[from] Box<DiagnosticMismatchError>),
     #[error(transparent)]
     PublishDiagnosticsMismatch(#[from] PublishDiagnosticsMismatchError),
     #[error(transparent)]

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -28,11 +28,11 @@ use crate::{
     responses::{
         get_code_lens_resolve_response, get_code_lens_response, get_completion_resolve_response,
         get_completion_response, get_declaration_response, get_definition_response,
-        get_diagnostics_response, get_document_highlight_response,
-        get_document_link_resolve_response, get_document_link_response,
-        get_document_symbol_response, get_folding_range_response, get_formatting_response,
-        get_hover_response, get_implementation_response, get_incoming_calls_response,
-        get_moniker_response, get_outgoing_calls_response, get_prepare_call_hierachy_response,
+        get_document_highlight_response, get_document_link_resolve_response,
+        get_document_link_response, get_document_symbol_response, get_folding_range_response,
+        get_formatting_response, get_hover_response, get_implementation_response,
+        get_incoming_calls_response, get_moniker_response, get_outgoing_calls_response,
+        get_prepare_call_hierachy_response, get_publish_diagnostics_response,
         get_references_response, get_rename_response, get_selection_range_response,
         get_semantic_tokens_full_delta_response, get_semantic_tokens_full_response,
         get_semantic_tokens_range_response, get_type_definition_response,
@@ -120,7 +120,7 @@ pub fn send_diagnostic_resp(uri: &Uri, connection: &Connection) -> Result<()> {
     };
     let response_num = receive_response_num(&root_path)?;
     info!("response_num: {response_num}");
-    let Some(publish_params) = get_diagnostics_response(response_num, uri) else {
+    let Some(publish_params) = get_publish_diagnostics_response(response_num, uri) else {
         error!("Invalid response number: {response_num}");
         return Ok(());
     };

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -22,7 +22,11 @@ use crate::get_dummy_source_path;
 /// For use with `test_document_highlight`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_document_highlight_response(response_num: u32) -> Option<Vec<DocumentHighlight>> {
+pub fn get_document_highlight_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<Vec<DocumentHighlight>> {
+    _ = uri;
     let item1 = DocumentHighlight {
         range: Range {
             start: Position::new(1, 2),
@@ -49,7 +53,8 @@ pub fn get_document_highlight_response(response_num: u32) -> Option<Vec<Document
 /// For use with `test_document_link`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_document_link_response(response_num: u32) -> Option<Vec<DocumentLink>> {
+pub fn get_document_link_response(response_num: u32, uri: &Uri) -> Option<Vec<DocumentLink>> {
+    _ = uri;
     let item1 = DocumentLink {
         range: Range {
             start: Position::new(1, 2),
@@ -90,7 +95,8 @@ pub fn get_document_link_response(response_num: u32) -> Option<Vec<DocumentLink>
 /// For use with `test_document_link_resolve`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_document_link_resolve_response(response_num: u32) -> Option<DocumentLink> {
+pub fn get_document_link_resolve_response(response_num: u32, uri: &Uri) -> Option<DocumentLink> {
+    _ = uri;
     let item1 = DocumentLink {
         range: Range {
             start: Position::new(1, 2),
@@ -129,7 +135,11 @@ pub fn get_document_link_resolve_response(response_num: u32) -> Option<DocumentL
 /// For use with `test_document_symbol`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_document_symbol_response(response_num: u32) -> Option<DocumentSymbolResponse> {
+pub fn get_document_symbol_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<DocumentSymbolResponse> {
+    _ = uri;
     #[allow(deprecated)]
     match response_num {
         0 => Some(DocumentSymbolResponse::Flat(vec![])),
@@ -170,7 +180,8 @@ pub fn get_document_symbol_response(response_num: u32) -> Option<DocumentSymbolR
 
 /// For use with `test_code_lens`.
 #[must_use]
-pub fn get_code_lens_response(response_num: u32) -> Option<Vec<CodeLens>> {
+pub fn get_code_lens_response(response_num: u32, uri: &Uri) -> Option<Vec<CodeLens>> {
+    _ = uri;
     let item1 = CodeLens {
         range: Range {
             start: Position::new(1, 2),
@@ -202,7 +213,8 @@ pub fn get_code_lens_response(response_num: u32) -> Option<Vec<CodeLens>> {
 
 /// For use with `test_code_lens_resolve`.
 #[must_use]
-pub fn get_code_lens_resolve_response(response_num: u32) -> Option<CodeLens> {
+pub fn get_code_lens_resolve_response(response_num: u32, uri: &Uri) -> Option<CodeLens> {
+    _ = uri;
     let item1 = CodeLens {
         range: Range {
             start: Position::new(1, 2),
@@ -232,7 +244,8 @@ pub fn get_code_lens_resolve_response(response_num: u32) -> Option<CodeLens> {
 
 /// For use with `test_completion`.
 #[must_use]
-pub fn get_completion_response(response_num: u32) -> Option<CompletionResponse> {
+pub fn get_completion_response(response_num: u32, uri: &Uri) -> Option<CompletionResponse> {
+    _ = uri;
     let item1 = CompletionItem {
         label: "label1".to_string(),
         label_details: Some(CompletionItemLabelDetails {
@@ -309,7 +322,8 @@ pub fn get_completion_response(response_num: u32) -> Option<CompletionResponse> 
 
 /// For use with `test_completion_resolve`.
 #[must_use]
-pub fn get_completion_resolve_response(response_num: u32) -> Option<CompletionItem> {
+pub fn get_completion_resolve_response(response_num: u32, uri: &Uri) -> Option<CompletionItem> {
+    _ = uri;
     match response_num {
         0 => Some(CompletionItem {
             label: "label1".to_string(),
@@ -364,7 +378,8 @@ pub fn get_completion_resolve_response(response_num: u32) -> Option<CompletionIt
 /// For use with `test_hover`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_hover_response(response_num: u32) -> Option<Hover> {
+pub fn get_hover_response(response_num: u32, uri: &Uri) -> Option<Hover> {
+    _ = uri;
     match response_num {
         0 => Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
@@ -459,14 +474,21 @@ pub fn get_hover_response(response_num: u32) -> Option<Hover> {
 /// Since `textDocument/definition` and `textDocument/implementation` have the same
 /// response, this just wraps `get_definition_response`.
 #[must_use]
-pub fn get_implementation_response(response_num: u32) -> Option<GotoImplementationResponse> {
-    get_definition_response(response_num)
+pub fn get_implementation_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<GotoImplementationResponse> {
+    get_definition_response(response_num, uri)
 }
 
 /// For use with `test_incoming_calls`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_incoming_calls_response(response_num: u32) -> Option<Vec<CallHierarchyIncomingCall>> {
+pub fn get_incoming_calls_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<Vec<CallHierarchyIncomingCall>> {
+    _ = uri;
     let item1 = CallHierarchyIncomingCall {
         from: CallHierarchyItem {
             name: "name1".to_string(),
@@ -522,7 +544,8 @@ pub fn get_incoming_calls_response(response_num: u32) -> Option<Vec<CallHierarch
 
 /// For use with `test_moniker`.
 #[must_use]
-pub fn get_moniker_response(response_num: u32) -> Option<Vec<Moniker>> {
+pub fn get_moniker_response(response_num: u32, uri: &Uri) -> Option<Vec<Moniker>> {
+    _ = uri;
     let item1 = Moniker {
         scheme: "scheme1".to_string(),
         identifier: "identifier1".to_string(),
@@ -547,7 +570,11 @@ pub fn get_moniker_response(response_num: u32) -> Option<Vec<Moniker>> {
 /// For use with `test_outgoing_calls`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_outgoing_calls_response(response_num: u32) -> Option<Vec<CallHierarchyOutgoingCall>> {
+pub fn get_outgoing_calls_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<Vec<CallHierarchyOutgoingCall>> {
+    _ = uri;
     let item1 = CallHierarchyOutgoingCall {
         to: CallHierarchyItem {
             name: "name1".to_string(),
@@ -604,7 +631,11 @@ pub fn get_outgoing_calls_response(response_num: u32) -> Option<Vec<CallHierarch
 /// For use with `test_prepare_call_hierarchy`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_prepare_call_hierachy_response(response_num: u32) -> Option<Vec<CallHierarchyItem>> {
+pub fn get_prepare_call_hierachy_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<Vec<CallHierarchyItem>> {
+    _ = uri;
     let item1 = CallHierarchyItem {
         name: "name1".to_string(),
         kind: SymbolKind::FILE,
@@ -816,14 +847,15 @@ pub fn get_publish_diagnostics_response(
 /// Since `textDocument/definition` and `textDocument/declaration` have the same response,
 /// this just wraps `get_definition_response`.
 #[must_use]
-pub fn get_declaration_response(response_num: u32) -> Option<GotoDeclarationResponse> {
-    get_definition_response(response_num)
+pub fn get_declaration_response(response_num: u32, uri: &Uri) -> Option<GotoDeclarationResponse> {
+    get_definition_response(response_num, uri)
 }
 
 /// For use with `test_definition`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_definition_response(response_num: u32) -> Option<GotoDefinitionResponse> {
+pub fn get_definition_response(response_num: u32, uri: &Uri) -> Option<GotoDefinitionResponse> {
+    _ = uri;
     let location_item = Location {
         uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
         range: Range {
@@ -867,7 +899,8 @@ pub fn get_definition_response(response_num: u32) -> Option<GotoDefinitionRespon
 /// For use with `test_rename`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_rename_response(response_num: u32) -> Option<WorkspaceEdit> {
+pub fn get_rename_response(response_num: u32, uri: &Uri) -> Option<WorkspaceEdit> {
+    _ = uri;
     match response_num {
         0 => Some(WorkspaceEdit {
             changes: Some(HashMap::new()),
@@ -936,7 +969,8 @@ pub fn get_rename_response(response_num: u32) -> Option<WorkspaceEdit> {
 /// For use with `test_references`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_references_response(response_num: u32) -> Option<Vec<Location>> {
+pub fn get_references_response(response_num: u32, uri: &Uri) -> Option<Vec<Location>> {
+    _ = uri;
     let uri = Uri::from_str(&get_dummy_source_path()).unwrap();
     match response_num {
         0 => Some(vec![]),
@@ -992,7 +1026,8 @@ pub fn get_references_response(response_num: u32) -> Option<Vec<Location>> {
 
 /// For use with `test_selection_range`.
 #[must_use]
-pub fn get_selection_range_response(response_num: u32) -> Option<Vec<SelectionRange>> {
+pub fn get_selection_range_response(response_num: u32, uri: &Uri) -> Option<Vec<SelectionRange>> {
+    _ = uri;
     let item1 = SelectionRange {
         range: Range {
             start: Position::new(1, 2),
@@ -1018,7 +1053,11 @@ pub fn get_selection_range_response(response_num: u32) -> Option<Vec<SelectionRa
 
 /// For use with `test_semantic_tokens_full`.
 #[must_use]
-pub fn get_semantic_tokens_full_response(response_num: u32) -> Option<SemanticTokensResult> {
+pub fn get_semantic_tokens_full_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<SemanticTokensResult> {
+    _ = uri;
     let item1 = SemanticToken {
         delta_line: 1,
         delta_start: 2,
@@ -1092,7 +1131,11 @@ pub fn get_semantic_tokens_full_response(response_num: u32) -> Option<SemanticTo
 
 /// For use with `test_semantic_tokens_range`.
 #[must_use]
-pub fn get_semantic_tokens_range_response(response_num: u32) -> Option<SemanticTokensRangeResult> {
+pub fn get_semantic_tokens_range_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<SemanticTokensRangeResult> {
+    _ = uri;
     let item1 = SemanticToken {
         delta_line: 1,
         delta_start: 2,
@@ -1153,7 +1196,9 @@ pub fn get_semantic_tokens_range_response(response_num: u32) -> Option<SemanticT
 #[allow(clippy::too_many_lines)]
 pub fn get_semantic_tokens_full_delta_response(
     response_num: u32,
+    uri: &Uri,
 ) -> Option<SemanticTokensFullDeltaResult> {
+    _ = uri;
     let token1 = SemanticToken {
         delta_line: 1,
         delta_start: 2,
@@ -1320,14 +1365,18 @@ pub fn get_semantic_tokens_full_delta_response(
 /// Since `textDocument/definition` and `textDocument/typeDefinition` have the same
 /// response, this just wraps `get_definition_response`.
 #[must_use]
-pub fn get_type_definition_response(response_num: u32) -> Option<GotoTypeDefinitionResponse> {
-    get_definition_response(response_num)
+pub fn get_type_definition_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<GotoTypeDefinitionResponse> {
+    get_definition_response(response_num, uri)
 }
 
 /// For use with `test_folding_range`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_folding_range_response(response_num: u32) -> Option<Vec<FoldingRange>> {
+pub fn get_folding_range_response(response_num: u32, uri: &Uri) -> Option<Vec<FoldingRange>> {
+    _ = uri;
     let item1 = FoldingRange {
         start_line: 0,
         start_character: None,
@@ -1365,7 +1414,8 @@ pub fn get_folding_range_response(response_num: u32) -> Option<Vec<FoldingRange>
 /// For use with `test_formatting`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_formatting_response(response_num: u32) -> Option<Vec<TextEdit>> {
+pub fn get_formatting_response(response_num: u32, uri: &Uri) -> Option<Vec<TextEdit>> {
+    _ = uri;
     match response_num {
         // NOTE: The dummy tests rely on a `response_num` of 0 to return an empty edit response
         0 => Some(vec![]),

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -644,10 +644,13 @@ pub fn get_prepare_call_hierachy_response(response_num: u32) -> Option<Vec<CallH
     }
 }
 
-/// For use with `test_diagnostics`.
+/// For use with `test_publish_diagnostics`.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn get_diagnostics_response(response_num: u32, uri: &Uri) -> Option<PublishDiagnosticsParams> {
+pub fn get_publish_diagnostics_response(
+    response_num: u32,
+    uri: &Uri,
+) -> Option<PublishDiagnosticsParams> {
     let item = Diagnostic {
         range: Range {
             start: Position::new(1, 2),

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -5,11 +5,13 @@ use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, ChangeAnnotation,
     CodeDescription, CodeLens, CompletionItem, CompletionItemKind, CompletionItemLabelDetails,
     CompletionList, CompletionResponse, Diagnostic, DiagnosticRelatedInformation, DocumentChanges,
-    DocumentHighlight, DocumentHighlightKind, DocumentLink, DocumentSymbol, DocumentSymbolResponse,
-    Documentation, FoldingRange, FoldingRangeKind, GotoDefinitionResponse, Hover, HoverContents,
-    LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind, Moniker,
-    MonikerKind, Position, PublishDiagnosticsParams, Range, SelectionRange, SemanticToken,
-    SemanticTokens, SemanticTokensDelta, SemanticTokensEdit, SemanticTokensFullDeltaResult,
+    DocumentDiagnosticReport, DocumentDiagnosticReportKind, DocumentHighlight,
+    DocumentHighlightKind, DocumentLink, DocumentSymbol, DocumentSymbolResponse, Documentation,
+    FoldingRange, FoldingRangeKind, FullDocumentDiagnosticReport, GotoDefinitionResponse, Hover,
+    HoverContents, LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind,
+    Moniker, MonikerKind, Position, PublishDiagnosticsParams, Range,
+    RelatedFullDocumentDiagnosticReport, SelectionRange, SemanticToken, SemanticTokens,
+    SemanticTokensDelta, SemanticTokensEdit, SemanticTokensFullDeltaResult,
     SemanticTokensPartialResult, SemanticTokensRangeResult, SemanticTokensResult,
     SymbolInformation, SymbolKind, SymbolTag, TextDocumentEdit, TextEdit, UniquenessLevel, Uri,
     WorkspaceEdit,
@@ -640,6 +642,119 @@ pub fn get_prepare_call_hierachy_response(response_num: u32) -> Option<Vec<CallH
         1 => Some(vec![item1]),
         2 => Some(vec![item2]),
         3 => Some(vec![item1, item2]),
+        _ => None,
+    }
+}
+
+/// For use with `test_diagnostic`.
+#[must_use]
+#[allow(clippy::missing_panics_doc, clippy::too_many_lines)]
+pub fn get_diagnostic_response(response_num: u32, uri: &Uri) -> Option<DocumentDiagnosticReport> {
+    let item1 = Diagnostic {
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        severity: Some(lsp_types::DiagnosticSeverity::ERROR),
+        code: None,
+        code_description: Some(CodeDescription {
+            href: Uri::from_str(&get_dummy_source_path()).unwrap(),
+        }),
+        source: None,
+        message: "message".to_string(),
+        tags: None,
+        related_information: Some(vec![DiagnosticRelatedInformation {
+            location: Location {
+                uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+                range: Range {
+                    start: Position::new(5, 6),
+                    end: Position::new(7, 8),
+                },
+            },
+            message: "related message".to_string(),
+        }]),
+        data: None,
+    };
+    let item2 = Diagnostic {
+        range: Range {
+            start: Position::new(1, 2),
+            end: Position::new(3, 4),
+        },
+        severity: Some(lsp_types::DiagnosticSeverity::ERROR),
+        code: None,
+        code_description: Some(CodeDescription {
+            href: Uri::from_str(&get_dummy_source_path()).unwrap(),
+        }),
+        source: None,
+        message: "message".to_string(),
+        tags: None,
+        related_information: Some(vec![DiagnosticRelatedInformation {
+            location: Location {
+                uri: Uri::from_str(&get_dummy_source_path()).unwrap(),
+                range: Range {
+                    start: Position::new(5, 6),
+                    end: Position::new(7, 8),
+                },
+            },
+            message: "related message".to_string(),
+        }]),
+        data: None,
+    };
+    let mut related_documents = HashMap::new();
+    related_documents.insert(
+        uri.clone(),
+        DocumentDiagnosticReportKind::Full(FullDocumentDiagnosticReport {
+            result_id: None,
+            items: vec![item1.clone()],
+        }),
+    );
+
+    match response_num {
+        0 => Some(DocumentDiagnosticReport::Full(
+            RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: vec![],
+                },
+            },
+        )),
+        1 => Some(DocumentDiagnosticReport::Full(
+            RelatedFullDocumentDiagnosticReport {
+                related_documents: Some(related_documents.clone()),
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: vec![],
+                },
+            },
+        )),
+        2 => Some(DocumentDiagnosticReport::Full(
+            RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: vec![item1],
+                },
+            },
+        )),
+        3 => Some(DocumentDiagnosticReport::Full(
+            RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: vec![item2],
+                },
+            },
+        )),
+        4 => Some(DocumentDiagnosticReport::Full(
+            RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: vec![item1, item2],
+                },
+            },
+        )),
         _ => None,
     }
 }

--- a/test-suite/src/code_lens.rs
+++ b/test-suite/src/code_lens.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -9,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{CodeLens, CodeLensOptions, Position, Range, ServerCapabilities};
+    use lsp_types::{CodeLens, CodeLensOptions, Position, Range, ServerCapabilities, Uri};
     use rstest::rstest;
 
     fn code_lens_capabilities_simple() -> ServerCapabilities {
@@ -38,7 +38,8 @@ mod test {
 
     #[rstest]
     fn test_server_code_lens_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
-        let resp = test_server::responses::get_code_lens_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_code_lens_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -56,7 +57,8 @@ mod test {
 
     #[rstest]
     fn test_server_code_lens_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
-        let resp = test_server::responses::get_code_lens_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_code_lens_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/code_lens_resolve.rs
+++ b/test-suite/src/code_lens_resolve.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod test {
+    use std::str::FromStr as _;
+
     use crate::test_helpers::NON_RESPONSE_NUM;
     use lspresso_shot::{
         lspresso_shot, test_code_lens_resolve,
@@ -7,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{CodeLens, CodeLensOptions, Range, ServerCapabilities};
+    use lsp_types::{CodeLens, CodeLensOptions, Range, ServerCapabilities, Uri};
     use rstest::rstest;
 
     fn code_lens_resolve_capabilities_simple() -> ServerCapabilities {
@@ -47,7 +49,9 @@ mod test {
 
     #[rstest]
     fn test_server_code_lens_resolve_expect_none_got_some(#[values(0, 1)] response_num: u32) {
-        let resp = test_server::responses::get_code_lens_resolve_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_code_lens_resolve_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -66,7 +70,9 @@ mod test {
 
     #[rstest]
     fn test_server_code_lens_simple_expect_some_got_some(#[values(0, 1)] response_num: u32) {
-        let resp = test_server::responses::get_code_lens_resolve_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_code_lens_resolve_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/completion.rs
+++ b/test-suite/src/completion.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -12,7 +12,7 @@ mod test {
     use lsp_types::{
         CompletionItem, CompletionItemKind, CompletionList, CompletionOptions,
         CompletionOptionsCompletionItem, CompletionResponse, CompletionTextEdit, Documentation,
-        InsertTextFormat, MarkupContent, Position, Range, ServerCapabilities, TextEdit,
+        InsertTextFormat, MarkupContent, Position, Range, ServerCapabilities, TextEdit, Uri,
         WorkDoneProgressOptions,
     };
     use rstest::rstest;
@@ -52,7 +52,8 @@ mod test {
     fn test_server_completion_exact_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_completion_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_completion_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -71,7 +72,8 @@ mod test {
     fn test_server_completion_exact_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_completion_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_completion_response(response_num, &uri).unwrap();
         let comp_result = CompletionResult::Exact(resp);
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
@@ -93,7 +95,8 @@ mod test {
     fn test_server_completion_contains_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_completion_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_completion_response(response_num, &uri).unwrap();
         let comp_result = match resp {
             CompletionResponse::Array(items)
             | CompletionResponse::List(CompletionList { items, .. }) => {

--- a/test-suite/src/completion_resolve.rs
+++ b/test-suite/src/completion_resolve.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -11,7 +11,7 @@ mod test {
 
     use lsp_types::{
         CompletionItem, CompletionItemKind, CompletionOptions, CompletionTextEdit, Documentation,
-        InsertTextFormat, MarkupContent, Position, Range, ServerCapabilities, TextEdit,
+        InsertTextFormat, MarkupContent, Position, Range, ServerCapabilities, TextEdit, Uri,
     };
     use rstest::rstest;
 
@@ -51,7 +51,9 @@ mod test {
 
     #[rstest]
     fn test_server_completion_simple_expect_none_got_some(#[values(0, 1)] response_num: u32) {
-        let resp = test_server::responses::get_completion_resolve_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_completion_resolve_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -70,7 +72,9 @@ mod test {
 
     #[rstest]
     fn test_server_completion_simple_expect_some_got_some(#[values(0, 1)] response_num: u32) {
-        let resp = test_server::responses::get_completion_resolve_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_completion_resolve_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/declaration.rs
+++ b/test-suite/src/declaration.rs
@@ -40,7 +40,8 @@ mod test {
     fn test_server_declaration_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_declaration_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_declaration_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -70,7 +71,8 @@ mod test {
     fn test_server_declaration_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_declaration_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_declaration_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -39,7 +39,8 @@ mod test {
     fn test_server_definition_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_definition_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_definition_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -69,7 +70,8 @@ mod test {
     fn test_server_definition_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_definition_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_definition_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/diagnostics.rs
+++ b/test-suite/src/diagnostics.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use crate::test_helpers::cargo_dot_toml;
     use lspresso_shot::{
-        lspresso_shot, test_diagnostics,
+        lspresso_shot, test_publish_diagnostics,
         types::{ServerStartType, TestCase, TestFile},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
@@ -34,9 +34,10 @@ mod tests {
     }
 
     #[rstest]
-    fn test_server_diagnostics_simple(#[values(0, 1, 2)] response_num: u32) {
+    fn test_server_publish_diagnostics_simple_expect_some_got_some(#[values(0, 1, 2)] response_num: u32) {
         let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
-        let resp = test_server::responses::get_diagnostics_response(response_num, &uri).unwrap();
+        let resp =
+            test_server::responses::get_publish_diagnostics_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -47,11 +48,11 @@ mod tests {
         send_capabiltiies(&diagnostic_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_diagnostics(test_case, &resp.diagnostics));
+        lspresso_shot!(test_publish_diagnostics(test_case, &resp.diagnostics));
     }
 
     #[test]
-    fn rust_analyzer_multi_diagnostics() {
+    fn rust_analyzer_publish_diagnostics_0() {
         let source_file = TestFile::new(
             "src/main.rs",
             "pub fn main() {
@@ -82,7 +83,7 @@ mod tests {
                 character: 11,
             },
         };
-        lspresso_shot!(test_diagnostics(
+        lspresso_shot!(test_publish_diagnostics(
             diagnostic_test_case,
             &vec![
                 Diagnostic {
@@ -124,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn rust_analyzer_diagnostics() {
+    fn rust_analyzer_publish_diagnostics_1() {
         let source_file = TestFile::new(
             "src/main.rs",
             r#"pub fn main() {
@@ -144,7 +145,7 @@ mod tests {
             "rendered".to_string(),
             serde_json::Value::String("error[E0765]: unterminated double quote string\n --> src/main.rs:2:14\n  |\n2 |       println!(\"Hello, world!\n  |  ______________^\n3 | | }\n  | |_^\n\n".to_string()),
         );
-        lspresso_shot!(test_diagnostics(
+        lspresso_shot!(test_publish_diagnostics(
             diagnostic_test_case,
             &vec![Diagnostic {
                 range: Range {

--- a/test-suite/src/document_highlight.rs
+++ b/test-suite/src/document_highlight.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -9,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{DocumentHighlight, OneOf, Position, Range, ServerCapabilities};
+    use lsp_types::{DocumentHighlight, OneOf, Position, Range, ServerCapabilities, Uri};
     use rstest::rstest;
 
     fn document_highlight_capabilities_simple() -> ServerCapabilities {
@@ -42,7 +42,9 @@ mod test {
     fn test_server_document_highlight_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_document_highlight_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_document_highlight_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -62,7 +64,9 @@ mod test {
     fn test_server_document_highlight_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_document_highlight_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_document_highlight_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/document_link.rs
+++ b/test-suite/src/document_link.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod test {
+    use std::str::FromStr as _;
+
     use crate::test_helpers::NON_RESPONSE_NUM;
     use lspresso_shot::{
         lspresso_shot, test_document_link,
@@ -7,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{DocumentLinkOptions, ServerCapabilities, WorkDoneProgressOptions};
+    use lsp_types::{DocumentLinkOptions, ServerCapabilities, Uri, WorkDoneProgressOptions};
     use rstest::rstest;
 
     fn document_link_capabilities_simple() -> ServerCapabilities {
@@ -41,7 +43,8 @@ mod test {
     fn test_server_document_link_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_document_link_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_document_link_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -61,7 +64,8 @@ mod test {
     fn test_server_document_link_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_document_link_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_document_link_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/document_link_resolve.rs
+++ b/test-suite/src/document_link_resolve.rs
@@ -64,8 +64,9 @@ mod test {
     fn test_server_document_link_resolve_simple_expect_none_got_some(
         #[values(0, 1, 2)] response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_document_link_resolve_response(response_num).unwrap();
+            test_server::responses::get_document_link_resolve_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -102,8 +103,9 @@ mod test {
 
     #[rstest]
     fn test_server_document_link_simple_expect_some_got_some(#[values(0, 1, 2)] response_num: u32) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_document_link_resolve_response(response_num).unwrap();
+            test_server::responses::get_document_link_resolve_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/document_symbol.rs
+++ b/test-suite/src/document_symbol.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -11,7 +11,7 @@ mod test {
 
     use lsp_types::{
         DocumentSymbol, DocumentSymbolResponse, OneOf, Position, Range, ServerCapabilities,
-        SymbolKind,
+        SymbolKind, Uri,
     };
     use rstest::rstest;
 
@@ -40,7 +40,9 @@ mod test {
     fn test_server_document_symbol_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let syms = test_server::responses::get_document_symbol_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let syms =
+            test_server::responses::get_document_symbol_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -73,7 +75,9 @@ mod test {
     fn test_server_document_symbol_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let syms = test_server::responses::get_document_symbol_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let syms =
+            test_server::responses::get_document_symbol_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/folding_range.rs
+++ b/test-suite/src/folding_range.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -9,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{FoldingRange, FoldingRangeProviderCapability, ServerCapabilities};
+    use lsp_types::{FoldingRange, FoldingRangeProviderCapability, ServerCapabilities, Uri};
     use rstest::rstest;
 
     fn folding_range_capabilities_simple() -> ServerCapabilities {
@@ -38,7 +38,8 @@ mod test {
     fn test_server_folding_range_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_folding_range_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_folding_range_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -58,7 +59,8 @@ mod test {
     fn test_server_folding_range_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_folding_range_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_folding_range_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/formatting.rs
+++ b/test-suite/src/formatting.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -9,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{OneOf, Position, Range, ServerCapabilities, TextEdit};
+    use lsp_types::{OneOf, Position, Range, ServerCapabilities, TextEdit, Uri};
     use rstest::rstest;
 
     fn formatting_capabilities_simple() -> ServerCapabilities {
@@ -58,7 +58,8 @@ mod test {
     fn test_server_formatting_response_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let edits = test_server::responses::get_formatting_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let edits = test_server::responses::get_formatting_response(response_num, &uri).unwrap();
         let source_file =
             TestFile::new(test_server::get_dummy_source_path(), "Some source contents");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
@@ -78,7 +79,8 @@ mod test {
     fn test_server_formatting_response_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let edits = test_server::responses::get_formatting_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let edits = test_server::responses::get_formatting_response(response_num, &uri).unwrap();
         let source_file =
             TestFile::new(test_server::get_dummy_source_path(), "Some source contents");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -11,7 +11,7 @@ mod test {
 
     use lsp_types::{
         Hover, HoverContents, HoverOptions, HoverProviderCapability, MarkupContent, MarkupKind,
-        Position, Range, ServerCapabilities, WorkDoneProgressOptions,
+        Position, Range, ServerCapabilities, Uri, WorkDoneProgressOptions,
     };
     use rstest::rstest;
 
@@ -55,7 +55,8 @@ mod test {
     fn test_server_hover_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_hover_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_hover_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -75,7 +76,8 @@ mod test {
     fn test_server_hover_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_hover_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_hover_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/implementation.rs
+++ b/test-suite/src/implementation.rs
@@ -40,7 +40,8 @@ mod test {
     fn test_server_implementation_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_implementation_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_implementation_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -70,7 +71,8 @@ mod test {
     fn test_server_implementation_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_implementation_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_implementation_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/incoming_calls.rs
+++ b/test-suite/src/incoming_calls.rs
@@ -71,7 +71,8 @@ mod test {
     fn test_server_incoming_calls_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_incoming_calls_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_incoming_calls_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -82,7 +83,7 @@ mod test {
         send_capabiltiies(&incoming_calls_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let mut call_item = get_prepare_call_hierachy_response(1).unwrap()[0].clone();
+        let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
         let test_result = test_incoming_calls(test_case.clone(), &call_item, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
@@ -93,7 +94,8 @@ mod test {
     fn test_server_incoming_calls_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_incoming_calls_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_incoming_calls_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -104,7 +106,7 @@ mod test {
         send_capabiltiies(&incoming_calls_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let mut call_item = get_prepare_call_hierachy_response(1).unwrap()[0].clone();
+        let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
         lspresso_shot!(test_incoming_calls(test_case, &call_item, Some(&resp)));
     }

--- a/test-suite/src/moniker.rs
+++ b/test-suite/src/moniker.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod test {
+    use std::str::FromStr as _;
+
     use crate::test_helpers::NON_RESPONSE_NUM;
     use lspresso_shot::{
         lspresso_shot, test_moniker,
@@ -7,7 +9,7 @@ mod test {
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
-    use lsp_types::{OneOf, Position, ServerCapabilities};
+    use lsp_types::{OneOf, Position, ServerCapabilities, Uri};
     use rstest::rstest;
 
     fn moniker_capabilities_simple() -> ServerCapabilities {
@@ -34,7 +36,8 @@ mod test {
 
     #[rstest]
     fn test_server_moniker_simple_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
-        let resp = test_server::responses::get_moniker_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_moniker_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -52,7 +55,8 @@ mod test {
 
     #[rstest]
     fn test_server_moniker_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
-        let resp = test_server::responses::get_moniker_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_moniker_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/outgoing_calls.rs
+++ b/test-suite/src/outgoing_calls.rs
@@ -71,7 +71,8 @@ mod test {
     fn test_server_outgoing_calls_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_outgoing_calls_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_outgoing_calls_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -82,7 +83,7 @@ mod test {
         send_capabiltiies(&outgoing_calls_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let mut call_item = get_prepare_call_hierachy_response(1).unwrap()[0].clone();
+        let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
         let test_result = test_outgoing_calls(test_case.clone(), &call_item, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
@@ -93,7 +94,8 @@ mod test {
     fn test_server_outgoing_calls_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_outgoing_calls_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_outgoing_calls_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -104,7 +106,7 @@ mod test {
         send_capabiltiies(&outgoing_calls_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let mut call_item = get_prepare_call_hierachy_response(1).unwrap()[0].clone();
+        let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
         lspresso_shot!(test_outgoing_calls(test_case, &call_item, Some(&resp)));
     }

--- a/test-suite/src/prepare_call_hierarchy.rs
+++ b/test-suite/src/prepare_call_hierarchy.rs
@@ -48,8 +48,9 @@ mod test {
     fn test_server_prepare_call_hierarchy_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_prepare_call_hierachy_response(response_num).unwrap();
+            test_server::responses::get_prepare_call_hierachy_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 
@@ -73,8 +74,9 @@ mod test {
     fn test_server_prepare_call_hierarchy_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_prepare_call_hierachy_response(response_num).unwrap();
+            test_server::responses::get_prepare_call_hierachy_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
 

--- a/test-suite/src/references.rs
+++ b/test-suite/src/references.rs
@@ -35,7 +35,8 @@ mod test {
 
     #[rstest]
     fn test_server_references_simple_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
-        let refs = test_server::responses::get_references_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let refs = test_server::responses::get_references_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -52,7 +53,8 @@ mod test {
 
     #[rstest]
     fn test_server_references_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
-        let refs = test_server::responses::get_references_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let refs = test_server::responses::get_references_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/rename.rs
+++ b/test-suite/src/rename.rs
@@ -40,7 +40,8 @@ mod test {
     fn test_server_rename_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let edits = test_server::responses::get_rename_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let edits = test_server::responses::get_rename_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -59,7 +60,8 @@ mod test {
     fn test_server_rename_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5)] response_num: u32,
     ) {
-        let edits = test_server::responses::get_rename_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let edits = test_server::responses::get_rename_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/selection_range.rs
+++ b/test-suite/src/selection_range.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -10,7 +10,7 @@ mod test {
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
 
     use lsp_types::{
-        Position, Range, SelectionRange, SelectionRangeProviderCapability, ServerCapabilities,
+        Position, Range, SelectionRange, SelectionRangeProviderCapability, ServerCapabilities, Uri,
     };
     use rstest::rstest;
 
@@ -39,7 +39,9 @@ mod test {
     fn test_server_selection_range_simple_expect_none_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_selection_range_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_selection_range_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -59,7 +61,9 @@ mod test {
     fn test_server_selection_range_simple_expect_some_got_some(
         #[values(0, 1, 2, 3)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_selection_range_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_selection_range_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/semantic_tokens_full.rs
+++ b/test-suite/src/semantic_tokens_full.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -15,7 +15,7 @@ mod test {
     use lsp_types::{
         SemanticToken, SemanticTokens, SemanticTokensFullOptions, SemanticTokensLegend,
         SemanticTokensOptions, SemanticTokensResult, SemanticTokensServerCapabilities,
-        ServerCapabilities, WorkDoneProgressOptions,
+        ServerCapabilities, Uri, WorkDoneProgressOptions,
     };
     use rstest::rstest;
 
@@ -53,7 +53,9 @@ mod test {
     fn test_server_semantic_tokens_full_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_semantic_tokens_full_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_semantic_tokens_full_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -109,7 +111,9 @@ mod test {
     fn test_server_semantic_tokens_full_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_semantic_tokens_full_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_semantic_tokens_full_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/semantic_tokens_full_delta.rs
+++ b/test-suite/src/semantic_tokens_full_delta.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::cargo_dot_toml;
     use lspresso_shot::{
@@ -12,7 +12,7 @@ mod test {
     use lsp_types::{
         SemanticToken, SemanticTokens, SemanticTokensDelta, SemanticTokensFullDeltaResult,
         SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-        SemanticTokensServerCapabilities, ServerCapabilities, WorkDoneProgressOptions,
+        SemanticTokensServerCapabilities, ServerCapabilities, Uri, WorkDoneProgressOptions,
     };
     use rstest::rstest;
 
@@ -59,8 +59,10 @@ mod test {
         )]
         response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_semantic_tokens_full_delta_response(response_num).unwrap();
+            test_server::responses::get_semantic_tokens_full_delta_response(response_num, &uri)
+                .unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -85,8 +87,10 @@ mod test {
         )]
         response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_semantic_tokens_full_delta_response(response_num).unwrap();
+            test_server::responses::get_semantic_tokens_full_delta_response(response_num, &uri)
+                .unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/semantic_tokens_range.rs
+++ b/test-suite/src/semantic_tokens_range.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{num::NonZeroU32, time::Duration};
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
 
     use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
     use lspresso_shot::{
@@ -12,7 +12,7 @@ mod test {
     use lsp_types::{
         Position, Range, SemanticToken, SemanticTokens, SemanticTokensLegend,
         SemanticTokensOptions, SemanticTokensRangeResult, SemanticTokensServerCapabilities,
-        ServerCapabilities, WorkDoneProgressOptions,
+        ServerCapabilities, Uri, WorkDoneProgressOptions,
     };
     use rstest::rstest;
 
@@ -57,8 +57,9 @@ mod test {
     fn test_server_semantic_tokens_range_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6, 7, 8)] response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_semantic_tokens_range_response(response_num).unwrap();
+            test_server::responses::get_semantic_tokens_range_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -137,8 +138,9 @@ mod test {
     fn test_server_semantic_tokens_range_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6, 7, 8)] response_num: u32,
     ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
         let resp =
-            test_server::responses::get_semantic_tokens_range_response(response_num).unwrap();
+            test_server::responses::get_semantic_tokens_range_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case

--- a/test-suite/src/type_definition.rs
+++ b/test-suite/src/type_definition.rs
@@ -40,7 +40,9 @@ mod test {
     fn test_server_type_definition_simple_expect_none_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_type_definition_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_type_definition_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case
@@ -70,7 +72,9 @@ mod test {
     fn test_server_type_definition_simple_expect_some_got_some(
         #[values(0, 1, 2, 3, 4, 5, 6)] response_num: u32,
     ) {
-        let resp = test_server::responses::get_type_definition_response(response_num).unwrap();
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_type_definition_response(response_num, &uri).unwrap();
         let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
         let test_case = TestCase::new(get_dummy_server_path(), source_file);
         let test_case_root = test_case


### PR DESCRIPTION
- Rewords the previous diagnostics tests to reflect the fact that they're testing `textDocument/publishDiagnostics`
- Implements `textDocument/diagnostic`
- Refactors the response getter functions in test-server to accept a `uri` parameter. Most don't use this. It may be helpful to include real URIs in our test responses down the road. If not, we can simply revert this and special-case the logic inside `handle_request()` for the `textDocument/diagnostic` case.