### PR TITLE
feat(lib): `textDocument/inlayHint`

### DIFF
--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -55,6 +55,7 @@ pub fn get_init_dot_lua(
         | TestType::Formatting
         | TestType::Hover
         | TestType::Implementation
+        | TestType::InlayHint
         | TestType::IncomingCalls
         | TestType::Moniker
         | TestType::OutgoingCalls
@@ -137,6 +138,7 @@ fn get_attach_action(test_type: TestType) -> String {
         TestType::Hover => include_str!("lua_templates/hover_action.lua"),
         TestType::Implementation => include_str!("lua_templates/implementation_action.lua"),
         TestType::IncomingCalls => include_str!("lua_templates/incoming_calls_action.lua"),
+        TestType::InlayHint => include_str!("lua_templates/inlay_hint_action.lua"),
         TestType::Moniker => include_str!("lua_templates/moniker_action.lua"),
         TestType::OutgoingCalls => include_str!("lua_templates/outgoing_calls_action.lua"),
         TestType::PrepareCallHierarchy => include_str!("lua_templates/prepare_call_hierarchy_action.lua"),

--- a/lspresso-shot/lua_templates/inlay_hint_action.lua
+++ b/lspresso-shot/lua_templates/inlay_hint_action.lua
@@ -1,0 +1,41 @@
+local progress_count = 0 -- track how many times we've tried for the logs
+
+---@diagnostic disable-next-line: unused-function, unused-local
+local function check_progress_result()
+    progress_count = progress_count + 1
+    if progress_count ~= PROGRESS_THRESHOLD then ---@diagnostic disable-line: undefined-global
+        report_log(tostring(progress_count) .. ' < ' .. tostring(PROGRESS_THRESHOLD) .. '\n') ---@diagnostic disable-line: undefined-global
+        return
+    end
+    -- Receive  json-encoded `Range` from the rust side in `json_range`
+    local json_range = [[
+RANGE
+    ]]
+    local range = vim.json.decode(json_range)
+
+    report_log('Range : ' .. vim.inspect(range) .. '\n') ---@diagnostic disable-line: undefined-global
+    report_log('Issuing inlay hint request (Attempt ' .. tostring(progress_count) .. ')\n') ---@diagnostic disable-line: undefined-global
+    local inlay_hint_result = vim.lsp.buf_request_sync(0, 'textDocument/inlayHint', {
+        textDocument = vim.lsp.util.make_text_document_params(0),
+        range = range,
+    })
+
+    if not inlay_hint_result then
+        ---@diagnostic disable-next-line: undefined-global
+        report_log('No valid inlay hint result returned: ' .. vim.inspect(inlay_hint_result) .. '\n')
+    elseif inlay_hint_result and #inlay_hint_result >= 1 and inlay_hint_result[1].result then
+        local results_file = io.open('RESULTS_FILE', 'w')
+        if not results_file then
+            report_error('Could not open results file') ---@diagnostic disable-line: undefined-global
+            exit() ---@diagnostic disable-line: undefined-global
+        end
+        ---@diagnostic disable: need-check-nil
+        results_file:write(vim.json.encode(inlay_hint_result[1].result, { escape_slash = true }))
+        results_file:close()
+        ---@diagnostic enable: need-check-nil
+    else
+        ---@diagnostic disable-next-line: undefined-global
+        mark_empty_file() ---@diagnostic disable-line: undefined-global
+    end
+    exit() ---@diagnostic disable-line: undefined-global
+end

--- a/lspresso-shot/types/hover.rs
+++ b/lspresso-shot/types/hover.rs
@@ -80,7 +80,7 @@ impl Compare for HoverContents {
                 writeln!(f, "{padding}{name_str}HoverContents::Scalar (")?;
                 MarkedString::compare(
                     f,
-                    Some("value"),
+                    Some("value"), // TODO: Check this!!!
                     expected,
                     actual,
                     depth + 1,

--- a/lspresso-shot/types/hover.rs
+++ b/lspresso-shot/types/hover.rs
@@ -78,26 +78,12 @@ impl Compare for HoverContents {
         match (expected, actual) {
             (Self::Scalar(expected), Self::Scalar(actual)) => {
                 writeln!(f, "{padding}{name_str}HoverContents::Scalar (")?;
-                MarkedString::compare(
-                    f,
-                    Some("value"), // TODO: Check this!!!
-                    expected,
-                    actual,
-                    depth + 1,
-                    override_color,
-                )?;
+                MarkedString::compare(f, None, expected, actual, depth + 1, override_color)?;
                 writeln!(f, "{padding})")?;
             }
             (Self::Array(expected), Self::Array(actual)) => {
                 writeln!(f, "{padding}{name_str}HoverContents::Array (")?;
-                <Vec<MarkedString>>::compare(
-                    f,
-                    Some("value"),
-                    expected,
-                    actual,
-                    depth + 1,
-                    override_color,
-                )?;
+                <Vec<MarkedString>>::compare(f, None, expected, actual, depth + 1, override_color)?;
                 writeln!(f, "{padding})")?;
             }
             (Self::Markup(expected), Self::Markup(actual)) => {

--- a/lspresso-shot/types/inlay_hint.rs
+++ b/lspresso-shot/types/inlay_hint.rs
@@ -1,0 +1,280 @@
+use lsp_types::{
+    Command, InlayHint, InlayHintKind, InlayHintLabel, InlayHintLabelPart,
+    InlayHintLabelPartTooltip, InlayHintTooltip, LSPAny, Location, MarkupContent, Position,
+    TextEdit,
+};
+use thiserror::Error;
+
+use super::{
+    compare::{cmp_fallback, Compare},
+    CleanResponse, Empty,
+};
+
+impl Empty for Vec<InlayHint> {}
+impl CleanResponse for Vec<InlayHint> {}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct InlayHintMismatchError {
+    pub test_id: String,
+    pub expected: Vec<InlayHint>,
+    pub actual: Vec<InlayHint>,
+}
+
+impl std::fmt::Display for InlayHintMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Test {}: Incorrect Inlay Hint response:", self.test_id)?;
+        <Vec<InlayHint>>::compare(f, None, &self.expected, &self.actual, 0, None)
+    }
+}
+
+impl Compare for InlayHint {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}InlayHint {{")?;
+        Position::compare(
+            f,
+            Some("position"),
+            &expected.position,
+            &actual.position,
+            depth + 1,
+            override_color,
+        )?;
+        InlayHintLabel::compare(
+            f,
+            Some("label"),
+            &expected.label,
+            &actual.label,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<InlayHintKind>>::compare(
+            f,
+            Some("kind"),
+            &expected.kind,
+            &actual.kind,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Vec<TextEdit>>>::compare(
+            f,
+            Some("text_edits"),
+            &expected.text_edits,
+            &actual.text_edits,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<InlayHintTooltip>>::compare(
+            f,
+            Some("tooltip"),
+            &expected.tooltip,
+            &actual.tooltip,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("padding_left"),
+            &expected.padding_left,
+            &actual.padding_left,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<bool>>::compare(
+            f,
+            Some("padding_right"),
+            &expected.padding_right,
+            &actual.padding_right,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<LSPAny>>::compare(
+            f,
+            Some("data"),
+            &expected.data,
+            &actual.data,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for InlayHintLabel {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::String(expected), Self::String(actual)) => {
+                writeln!(f, "{padding}{name_str}InlayHintLabel::String (")?;
+                String::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::LabelParts(expected), Self::LabelParts(actual)) => {
+                writeln!(f, "{padding}{name_str}InlayHintLabel::String (")?;
+                <Vec<InlayHintLabelPart>>::compare(
+                    f,
+                    None,
+                    expected,
+                    actual,
+                    depth + 1,
+                    override_color,
+                )?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Compare for InlayHintLabelPart {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        writeln!(f, "{padding}{name_str}InlayHintLabelPart {{")?;
+        String::compare(
+            f,
+            Some("value"),
+            &expected.value,
+            &actual.value,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<InlayHintLabelPartTooltip>>::compare(
+            f,
+            Some("tooltip"),
+            &expected.tooltip,
+            &actual.tooltip,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Location>>::compare(
+            f,
+            Some("location"),
+            &expected.location,
+            &actual.location,
+            depth + 1,
+            override_color,
+        )?;
+        <Option<Command>>::compare(
+            f,
+            Some("command"),
+            &expected.command,
+            &actual.command,
+            depth + 1,
+            override_color,
+        )?;
+        writeln!(f, "{padding}}}")?;
+
+        Ok(())
+    }
+}
+
+impl Compare for InlayHintLabelPartTooltip {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::String(expected), Self::String(actual)) => {
+                writeln!(f, "{padding}{name_str}InlayHintLabelPartTooltip::String (")?;
+                String::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::MarkupContent(expected), Self::MarkupContent(actual)) => {
+                writeln!(
+                    f,
+                    "{padding}{name_str}InlayHintLabelPartTooltip::MarkupContent ("
+                )?;
+                MarkupContent::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        Ok(())
+    }
+}
+
+impl Compare for InlayHintKind {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        cmp_fallback(f, expected, actual, depth, name, override_color)
+    }
+}
+
+impl Compare for InlayHintTooltip {
+    type Nested1 = ();
+    type Nested2 = ();
+    fn compare(
+        f: &mut std::fmt::Formatter<'_>,
+        name: Option<&str>,
+        expected: &Self,
+        actual: &Self,
+        depth: usize,
+        override_color: Option<anstyle::Color>,
+    ) -> std::fmt::Result {
+        let padding = "  ".repeat(depth);
+        let name_str = name.map_or_else(String::new, |name| format!("{name}: "));
+        match (expected, actual) {
+            (Self::String(expected), Self::String(actual)) => {
+                writeln!(f, "{padding}{name_str}InlayHintTooltip::String (")?;
+                String::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            (Self::MarkupContent(expected), Self::MarkupContent(actual)) => {
+                writeln!(f, "{padding}{name_str}InlayHintTooltip::MarkupContent (")?;
+                MarkupContent::compare(f, None, expected, actual, depth + 1, override_color)?;
+                writeln!(f, "{padding})")?;
+            }
+            _ => cmp_fallback(f, expected, actual, depth, name, override_color)?,
+        }
+        Ok(())
+    }
+}

--- a/lspresso-shot/types/mod.rs
+++ b/lspresso-shot/types/mod.rs
@@ -13,6 +13,7 @@ pub mod folding_range;
 pub mod formatting;
 pub mod hover;
 pub mod implementation;
+pub mod inlay_hint;
 pub mod moniker;
 pub mod references;
 pub mod rename;
@@ -66,6 +67,7 @@ use std::{
     time::Duration,
 };
 
+use inlay_hint::InlayHintMismatchError;
 use lsp_types::{Position, Uri};
 use rand::distr::Distribution as _;
 use serde::{Deserialize, Serialize};
@@ -108,6 +110,8 @@ pub enum TestType {
     Implementation,
     /// Test `callHierarchy/incomingCalls` requests
     IncomingCalls,
+    /// Test `textDocument/inlayHint` requests
+    InlayHint,
     /// Test `textDocument/moniker` requests
     Moniker,
     /// Test `callHierarchy/outgoingCalls` requests
@@ -159,6 +163,7 @@ impl std::fmt::Display for TestType {
                 Self::Hover => "textDocument/hover",
                 Self::Implementation => "textDocument/implementation",
                 Self::IncomingCalls => "callHierarchy/incomingCalls",
+                Self::InlayHint => "textDocument/inlayHint",
                 Self::Moniker => "textDocument/moniker",
                 Self::OutgoingCalls => "callHierarchy/outgoingCalls",
                 Self::PrepareCallHierarchy => "textDocument/prepareCallHierarchy",
@@ -660,6 +665,8 @@ pub enum TestError {
     HoverMismatch(#[from] Box<HoverMismatchError>),
     #[error(transparent)]
     ImplementationMismatch(#[from] Box<ImplementationMismatchError>),
+    #[error(transparent)]
+    InlayHintMismatch(#[from] InlayHintMismatchError),
     #[error(transparent)]
     IncomingCallsMismatch(#[from] IncomingCallsMismatchError),
     #[error(transparent)]

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -11,17 +11,19 @@ use lsp_types::{
         DocumentHighlightRequest, DocumentLinkRequest, DocumentLinkResolve, DocumentSymbolRequest,
         FoldingRangeRequest, Formatting, GotoDeclaration, GotoDeclarationParams, GotoDefinition,
         GotoImplementation, GotoImplementationParams, GotoTypeDefinition, GotoTypeDefinitionParams,
-        HoverRequest, MonikerRequest, References, Rename, Request as _, ResolveCompletionItem,
-        SelectionRangeRequest, SemanticTokensFullDeltaRequest, SemanticTokensFullRequest,
-        SemanticTokensRangeRequest, SignatureHelpRequest, WorkspaceDiagnosticRequest,
+        HoverRequest, InlayHintRequest, MonikerRequest, References, Rename, Request as _,
+        ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullDeltaRequest,
+        SemanticTokensFullRequest, SemanticTokensRangeRequest, SignatureHelpRequest,
+        WorkspaceDiagnosticRequest,
     },
     CallHierarchyIncomingCallsParams, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     CodeActionParams, CodeLens, CodeLensParams, CompletionItem, CompletionParams,
     DocumentDiagnosticParams, DocumentFormattingParams, DocumentHighlightParams, DocumentLink,
     DocumentLinkParams, DocumentSymbolParams, FoldingRangeParams, GotoDefinitionParams,
-    HoverParams, MonikerParams, ReferenceParams, RenameParams, SelectionRangeParams,
-    SemanticTokensDeltaParams, SemanticTokensParams, SemanticTokensRangeParams, ServerCapabilities,
-    SignatureHelpParams, Uri, WorkspaceDiagnosticParams,
+    HoverParams, InlayHintParams, MonikerParams, ReferenceParams, RenameParams,
+    SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensParams,
+    SemanticTokensRangeParams, ServerCapabilities, SignatureHelpParams, Uri,
+    WorkspaceDiagnosticParams,
 };
 
 use crate::{
@@ -33,12 +35,12 @@ use crate::{
         get_document_link_resolve_response, get_document_link_response,
         get_document_symbol_response, get_folding_range_response, get_formatting_response,
         get_hover_response, get_implementation_response, get_incoming_calls_response,
-        get_moniker_response, get_outgoing_calls_response, get_prepare_call_hierachy_response,
-        get_publish_diagnostics_response, get_references_response, get_rename_response,
-        get_selection_range_response, get_semantic_tokens_full_delta_response,
-        get_semantic_tokens_full_response, get_semantic_tokens_range_response,
-        get_signature_help_response, get_type_definition_response,
-        get_workspace_diagnostics_response,
+        get_inlay_hint_response, get_moniker_response, get_outgoing_calls_response,
+        get_prepare_call_hierachy_response, get_publish_diagnostics_response,
+        get_references_response, get_rename_response, get_selection_range_response,
+        get_semantic_tokens_full_delta_response, get_semantic_tokens_full_response,
+        get_semantic_tokens_range_response, get_signature_help_response,
+        get_type_definition_response, get_workspace_diagnostics_response,
     },
 };
 
@@ -387,6 +389,15 @@ pub fn handle_request(
                 |params: HoverParams| -> Uri {
                     params.text_document_position_params.text_document.uri
                 }
+            )?;
+        }
+        InlayHintRequest::METHOD => {
+            handle_request!(
+                InlayHintRequest,
+                get_inlay_hint_response,
+                req,
+                conn,
+                |params: InlayHintParams| -> Uri { params.text_document.uri }
             )?;
         }
         MonikerRequest::METHOD => {

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -9,9 +9,10 @@ use lsp_types::{
     DocumentDiagnosticReport, DocumentDiagnosticReportKind, DocumentHighlight,
     DocumentHighlightKind, DocumentLink, DocumentSymbol, DocumentSymbolResponse, Documentation,
     FoldingRange, FoldingRangeKind, FullDocumentDiagnosticReport, GotoDefinitionResponse, Hover,
-    HoverContents, LanguageString, Location, LocationLink, MarkedString, MarkupContent, MarkupKind,
-    Moniker, MonikerKind, ParameterInformation, ParameterLabel, Position, PublishDiagnosticsParams,
-    Range, RelatedFullDocumentDiagnosticReport, SelectionRange, SemanticToken, SemanticTokens,
+    HoverContents, InlayHint, InlayHintKind, InlayHintLabel, InlayHintTooltip, LanguageString,
+    Location, LocationLink, MarkedString, MarkupContent, MarkupKind, Moniker, MonikerKind,
+    ParameterInformation, ParameterLabel, Position, PublishDiagnosticsParams, Range,
+    RelatedFullDocumentDiagnosticReport, SelectionRange, SemanticToken, SemanticTokens,
     SemanticTokensDelta, SemanticTokensEdit, SemanticTokensFullDeltaResult,
     SemanticTokensPartialResult, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
     SignatureInformation, SymbolInformation, SymbolKind, SymbolTag, TextDocumentEdit, TextEdit,
@@ -22,7 +23,7 @@ use lsp_types::{
 
 use crate::get_dummy_source_path;
 
-/// For use with `test_document_highlight`.
+/// For use with `test_code_action`.
 pub fn get_code_action_response(response_num: u32, uri: &Uri) -> Option<CodeActionResponse> {
     _ = uri;
     let cmd = CodeActionOrCommand::Command(Command {
@@ -496,6 +497,42 @@ pub fn get_hover_response(response_num: u32, uri: &Uri) -> Option<Hover> {
                 end: Position::new(15, 16),
             }),
         }),
+        _ => None,
+    }
+}
+
+/// For use with `test_inlay_hint`.
+#[must_use]
+pub fn get_inlay_hint_response(response_num: u32, uri: &Uri) -> Option<Vec<InlayHint>> {
+    _ = uri;
+    let hint1 = InlayHint {
+        kind: Some(InlayHintKind::TYPE),
+        label: InlayHintLabel::String("label1".to_string()),
+        padding_left: Some(true),
+        padding_right: Some(false),
+        tooltip: Some(InlayHintTooltip::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: "tooltip1".to_string(),
+        })),
+        position: Position::new(1, 2),
+        text_edits: None,
+        data: None,
+    };
+    let hint2 = InlayHint {
+        kind: None,
+        label: InlayHintLabel::String("label2".to_string()),
+        padding_left: None,
+        padding_right: Some(true),
+        tooltip: Some(InlayHintTooltip::String("tooltip2".to_string())),
+        position: Position::new(3, 4),
+        text_edits: None,
+        data: None,
+    };
+    match response_num {
+        0 => Some(vec![]),
+        1 => Some(vec![hint1]),
+        2 => Some(vec![hint2]),
+        3 => Some(vec![hint1, hint2]),
         _ => None,
     }
 }

--- a/test-suite/src/inlay_hint.rs
+++ b/test-suite/src/inlay_hint.rs
@@ -1,0 +1,155 @@
+#[cfg(test)]
+mod test {
+    use std::{num::NonZeroU32, str::FromStr as _, time::Duration};
+
+    use crate::test_helpers::{cargo_dot_toml, NON_RESPONSE_NUM};
+    use lspresso_shot::{
+        lspresso_shot, test_inlay_hint,
+        types::{ServerStartType, TestCase, TestError, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{
+        InlayHint, InlayHintKind, InlayHintLabel, OneOf, Position, Range, ServerCapabilities, Uri,
+    };
+    use rstest::rstest;
+
+    fn inlay_hint_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            inlay_hint_provider: Some(OneOf::Left(true)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_server_inlay_hint_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&inlay_hint_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_inlay_hint(test_case, &Range::default(), None, None));
+    }
+
+    #[rstest]
+    fn test_server_inlay_hint_simple_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_inlay_hint_response(response_num, &uri).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&inlay_hint_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        let test_result = test_inlay_hint(test_case.clone(), &Range::default(), None, None);
+        let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_implementation_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3)] response_num: u32,
+    ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp = test_server::responses::get_inlay_hint_response(response_num, &uri).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&inlay_hint_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_inlay_hint(
+            test_case,
+            &Range::default(),
+            None,
+            Some(&resp)
+        ));
+    }
+
+    #[test]
+    fn rust_analyzer_inlay_hint() {
+        let source_file = TestFile::new(
+            "src/main.rs",
+            "pub fn main() {
+    let x = 1;
+}",
+        );
+        let test_case = TestCase::new("rust-analyzer", source_file)
+            .start_type(ServerStartType::Progress(
+                NonZeroU32::new(5).unwrap(),
+                "rustAnalyzer/cachePriming".to_string(),
+            ))
+            .timeout(Duration::from_secs(20))
+            .other_file(cargo_dot_toml());
+
+        let cmp = |expected: &Vec<InlayHint>, actual: &Vec<InlayHint>, test_case: &TestCase| {
+            _ = test_case;
+            if expected.len() != actual.len() {
+                return false;
+            }
+            for (exp, act) in expected.iter().zip(actual.iter()) {
+                if exp.position != act.position {
+                    return false;
+                }
+                if exp.label != act.label {
+                    return false;
+                }
+                if exp.kind != act.kind {
+                    return false;
+                }
+                if exp.text_edits != act.text_edits {
+                    return false;
+                }
+                if exp.tooltip != act.tooltip {
+                    return false;
+                }
+                if exp.padding_left != act.padding_left {
+                    return false;
+                }
+                if exp.padding_right != act.padding_right {
+                    return false;
+                }
+                // ignore data
+            }
+            true
+        };
+
+        lspresso_shot!(test_inlay_hint(
+            test_case,
+            &Range::new(
+                Position {
+                    line: 0,
+                    character: 0,
+                },
+                Position {
+                    line: 2,
+                    character: 1,
+                },
+            ),
+            Some(cmp),
+            Some(&vec![InlayHint {
+                position: Position {
+                    line: 1,
+                    character: 9,
+                },
+                label: InlayHintLabel::String(": i32".to_string()),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: None,
+                tooltip: None,
+                padding_left: Some(false,),
+                padding_right: Some(false,),
+                data: None,
+            }]),
+        ));
+    }
+}

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -17,6 +17,7 @@ mod formatting;
 mod hover;
 mod implementation;
 mod incoming_calls;
+mod inlay_hint;
 mod moniker;
 mod outgoing_calls;
 mod prepare_call_hierarchy;


### PR DESCRIPTION
Supersedes #33

I think the next thing to do here is rip out `Compare`.