### PR TITLE
feat(lib): add custom comparator param to all `test_*` functions

### DIFF
--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -41,7 +41,7 @@ use types::{
     },
     code_action::{CodeActionMismatchError, CodeActionResolveMismatchError},
     code_lens::{CodeLensMismatchError, CodeLensResolveMismatchError},
-    completion::{CompletionMismatchError, CompletionResolveMismatchError, CompletionResult},
+    completion::{CompletionMismatchError, CompletionResolveMismatchError},
     declaration::DeclarationMismatchError,
     definition::DefinitionMismatchError,
     diagnostic::{
@@ -525,7 +525,7 @@ pub fn test_code_lens_resolve(
     )
 }
 
-pub type CompletionComparator = fn(&CompletionResult, &CompletionResponse, &TestCase) -> bool;
+pub type CompletionComparator = fn(&CompletionResponse, &CompletionResponse, &TestCase) -> bool;
 
 /// Tests the server's response to a [`textDocument/completion`] request
 ///
@@ -544,7 +544,7 @@ pub fn test_completion(
     mut test_case: TestCase,
     cursor_pos: &Position,
     cmp: Option<CompletionComparator>,
-    expected: Option<&CompletionResult>,
+    expected: Option<&CompletionResponse>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::Completion);
     collect_results(
@@ -556,7 +556,7 @@ pub fn test_completion(
         expected,
         |expected, actual| {
             let eql = cmp.as_ref().map_or_else(
-                || expected.results_satisfy(actual),
+                || expected == actual,
                 |cmp_fn| cmp_fn(expected, actual, &test_case),
             );
             if !eql {

--- a/lspresso-shot/types/completion.rs
+++ b/lspresso-shot/types/completion.rs
@@ -1,10 +1,7 @@
-use lsp_types::{CompletionItem, CompletionList, CompletionResponse};
+use lsp_types::{CompletionItem, CompletionResponse};
 use thiserror::Error;
 
-use super::{
-    compare::{paint, write_fields_comparison, RED},
-    CleanResponse, Empty,
-};
+use super::{compare::write_fields_comparison, CleanResponse, Empty};
 
 impl Empty for CompletionResponse {}
 impl Empty for CompletionItem {}
@@ -30,180 +27,17 @@ impl std::fmt::Display for CompletionResolveMismatchError {
     }
 }
 
-// `textDocument/completion` is a bit different from other requests. Servers commonly
-// send a *bunch* of completion items and rely on the editor's lsp client to filter
-// them out/ display the most relevant ones first. This is fine, but it means that
-// doing a simple equality check for this isn't realistic and would be a serious
-// pain for library consumers. I'd like to experiment with the different ways we
-// can handle this, but for now we'll just allow for exact matching, and a simple
-// "contains" check.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CompletionResult {
-    /// Expect this exact set of completion items in the provided order
-    Exact(CompletionResponse),
-    /// Expect to at least see these completion items in any order.
-    /// NOTE: This discards the `CompletionList.is_incomplete` field and only
-    /// considers `CompletionList.items`
-    Contains(Vec<CompletionItem>),
-}
-
-impl CompletionResult {
-    /// Compares the expected results in `self` to the `actual` results, respecting
-    /// the intended behavior for each enum variant of `Self`
-    ///
-    /// Returns true if the two are considered equal, false otherwise
-    #[must_use]
-    pub fn results_satisfy(&self, actual: &CompletionResponse) -> bool {
-        match self {
-            Self::Contains(expected_results) => {
-                let actual_items = match actual {
-                    CompletionResponse::Array(a) => a,
-                    CompletionResponse::List(CompletionList { items, .. }) => items,
-                };
-                let mut expected = expected_results.clone();
-                for item in actual_items {
-                    if let Some(i) = expected
-                        .iter()
-                        .enumerate()
-                        .find(|(_, e)| *e == item)
-                        .map(|(i, _)| i)
-                    {
-                        expected.remove(i);
-                    }
-                }
-
-                expected.is_empty()
-            }
-            Self::Exact(expected_results) => match (expected_results, actual) {
-                (CompletionResponse::Array(expected), CompletionResponse::Array(actual)) => {
-                    expected == actual
-                }
-                (
-                    CompletionResponse::List(CompletionList {
-                        is_incomplete: expected_is_incomplete,
-                        items: expected_items,
-                    }),
-                    CompletionResponse::List(CompletionList {
-                        is_incomplete: actual_is_incomplete,
-                        items: actual_items,
-                    }),
-                ) => {
-                    expected_is_incomplete == actual_is_incomplete && expected_items == actual_items
-                }
-                (CompletionResponse::Array(_), CompletionResponse::List(_))
-                | (CompletionResponse::List(_), CompletionResponse::Array(_)) => false,
-            },
-        }
-    }
-}
-
 #[derive(Debug, Error, PartialEq, Eq)]
 pub struct CompletionMismatchError {
     pub test_id: String,
-    pub expected: CompletionResult,
+    pub expected: CompletionResponse,
     pub actual: CompletionResponse,
 }
 
-// TODO: Cleanup/ consolidate this logic with Self::compare_results
 impl std::fmt::Display for CompletionMismatchError {
     #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.expected {
-            CompletionResult::Contains(expected_results) => {
-                let actual_items = match &self.actual {
-                    CompletionResponse::Array(a) => a,
-                    CompletionResponse::List(CompletionList { items, .. }) => items,
-                };
-                let mut expected = expected_results.clone();
-                for item in actual_items {
-                    if let Some(i) = expected
-                        .iter()
-                        .enumerate()
-                        .find(|(_, e)| **e == *item)
-                        .map(|(i, _)| i)
-                    {
-                        expected.remove(i);
-                    }
-                }
-
-                writeln!(
-                    f,
-                    "Unprovided item{}:",
-                    if expected.len() > 1 { "s" } else { "" }
-                )?;
-                for item in &expected {
-                    writeln!(
-                        f,
-                        "{}",
-                        paint(RED, &format!("{}", serde_json::to_value(item).unwrap()))
-                    )?;
-                }
-                writeln!(
-                    f,
-                    "\nProvided item{}:",
-                    if actual_items.len() > 1 { "s" } else { "" }
-                )?;
-                for item in actual_items {
-                    writeln!(
-                        f,
-                        "{}",
-                        paint(RED, &format!("{}", serde_json::to_value(item).unwrap()))
-                    )?;
-                }
-            }
-            CompletionResult::Exact(expected_results) => match (expected_results, &self.actual) {
-                (CompletionResponse::Array(_), CompletionResponse::Array(_))
-                | (CompletionResponse::List(_), CompletionResponse::List(_)) => {
-                    write_fields_comparison(
-                        f,
-                        "CompletionResponse",
-                        expected_results,
-                        &self.actual,
-                        0,
-                    )?;
-                }
-                // Different completion types, indicate so and compare the inner items
-                (
-                    CompletionResponse::Array(expected_items),
-                    CompletionResponse::List(CompletionList {
-                        items: actual_items,
-                        ..
-                    }),
-                ) => {
-                    writeln!(
-                        f,
-                        "Expected `CompletionResponse::Array`, got `CompletionResponse::List`"
-                    )?;
-                    write_fields_comparison(
-                        f,
-                        "CompletionResponse",
-                        expected_items,
-                        actual_items,
-                        0,
-                    )?;
-                }
-                (
-                    CompletionResponse::List(CompletionList {
-                        items: expected_items,
-                        ..
-                    }),
-                    CompletionResponse::Array(actual_items),
-                ) => {
-                    writeln!(
-                        f,
-                        "Expected `CompletionResponse::List`, got `CompletionResponse::Array`"
-                    )?;
-                    write_fields_comparison(
-                        f,
-                        "CompletionResponse",
-                        expected_items,
-                        actual_items,
-                        0,
-                    )?;
-                }
-            },
-        }
-
-        Ok(())
+        writeln!(f, "Test {}: Incorrect Completion response:", self.test_id)?;
+        write_fields_comparison(f, "Completion", &self.expected, &self.actual, 0)
     }
 }

--- a/test-suite/src/code_action.rs
+++ b/test-suite/src/code_action.rs
@@ -163,7 +163,7 @@ mod test {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))

--- a/test-suite/src/completion.rs
+++ b/test-suite/src/completion.rs
@@ -45,7 +45,7 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_completion(test_case, &Position::default(), None));
+        lspresso_shot!(test_completion(test_case, &Position::default(), None, None));
     }
 
     #[rstest]
@@ -63,7 +63,7 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_completion(test_case.clone(), &Position::default(), None);
+        let test_result = test_completion(test_case.clone(), &Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -87,6 +87,7 @@ mod test {
         lspresso_shot!(test_completion(
             test_case,
             &Position::default(),
+            None,
             Some(&comp_result)
         ));
     }
@@ -115,6 +116,7 @@ mod test {
         lspresso_shot!(test_completion(
             test_case,
             &Position::default(),
+            None,
             Some(&comp_result)
         ));
     }
@@ -217,7 +219,7 @@ println!("format {local_variable} arguments");
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -226,6 +228,7 @@ println!("format {local_variable} arguments");
         lspresso_shot!(test_completion(
             test_case,
             &Position::new(1, 9),
+            None,
             Some(&expected_comps)
         ));
     }

--- a/test-suite/src/completion_resolve.rs
+++ b/test-suite/src/completion_resolve.rs
@@ -46,7 +46,12 @@ mod test {
             .expect("Failed to send capabilities");
         let completion_item = get_dummy_completion(&test_case);
 
-        lspresso_shot!(test_completion_resolve(test_case, &completion_item, None));
+        lspresso_shot!(test_completion_resolve(
+            test_case,
+            &completion_item,
+            None,
+            None
+        ));
     }
 
     #[rstest]
@@ -65,7 +70,7 @@ mod test {
             .expect("Failed to send capabilities");
         let completion_item = get_dummy_completion(&test_case);
 
-        let test_result = test_completion_resolve(test_case.clone(), &completion_item, None);
+        let test_result = test_completion_resolve(test_case.clone(), &completion_item, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -89,6 +94,7 @@ mod test {
         lspresso_shot!(test_completion_resolve(
             test_case,
             &completion_item,
+            None,
             Some(&resp)
         ));
     }
@@ -194,6 +200,7 @@ println!("format {local_variable} arguments");
         lspresso_shot!(test_completion_resolve(
             test_case,
             &completion_item,
+            None,
             Some(&completion_item)
         ));
     }

--- a/test-suite/src/declaration.rs
+++ b/test-suite/src/declaration.rs
@@ -33,7 +33,12 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_declaration(test_case, &Position::default(), None));
+        lspresso_shot!(test_declaration(
+            test_case,
+            &Position::default(),
+            None,
+            None
+        ));
     }
 
     #[rstest]
@@ -49,7 +54,7 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_declaration(test_case.clone(), &Position::default(), None);
+        let test_result = test_declaration(test_case.clone(), &Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -81,6 +86,7 @@ mod test {
         lspresso_shot!(test_declaration(
             test_case,
             &Position::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -96,7 +102,7 @@ mod test {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -105,6 +111,7 @@ mod test {
         lspresso_shot!(test_declaration(
             test_case,
             &Position::new(2, 5),
+            None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -32,7 +32,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_definition(test_case, &Position::default(), None));
+        lspresso_shot!(test_definition(test_case, &Position::default(), None, None));
     }
 
     #[rstest]
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_definition(test_case.clone(), &Position::default(), None);
+        let test_result = test_definition(test_case.clone(), &Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -80,6 +80,7 @@ mod test {
         lspresso_shot!(test_definition(
             test_case,
             &Position::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -104,6 +105,7 @@ mod test {
         lspresso_shot!(test_definition(
             test_case,
             &Position::new(2, 5),
+            None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {

--- a/test-suite/src/diagnostics.rs
+++ b/test-suite/src/diagnostics.rs
@@ -65,7 +65,7 @@ mod tests {
         send_capabiltiies(&diagnostic_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_diagnostic(test_case, None, None, &resp));
+        lspresso_shot!(test_diagnostic(test_case, None, None, None, &resp));
     }
 
     #[rstest]
@@ -85,7 +85,7 @@ mod tests {
         send_capabiltiies(&diagnostic_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_publish_diagnostics(test_case, &resp.diagnostics));
+        lspresso_shot!(test_publish_diagnostics(test_case, None, &resp.diagnostics));
     }
 
     #[rstest]
@@ -115,6 +115,7 @@ mod tests {
             test_case,
             Some(path),
             &Vec::new(),
+            None,
             &resp
         ));
     }
@@ -137,6 +138,7 @@ mod tests {
 
         lspresso_shot!(test_diagnostic(
             diagnostic_test_case,
+            None,
             None,
             None,
             &DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
@@ -183,6 +185,7 @@ mod tests {
         };
         lspresso_shot!(test_publish_diagnostics(
             diagnostic_test_case,
+            None,
             &vec![
                 Diagnostic {
                     range,
@@ -245,6 +248,7 @@ mod tests {
         );
         lspresso_shot!(test_publish_diagnostics(
             diagnostic_test_case,
+            None,
             &vec![Diagnostic {
                 range: Range {
                     start: Position {

--- a/test-suite/src/document_highlight.rs
+++ b/test-suite/src/document_highlight.rs
@@ -34,6 +34,7 @@ mod test {
         lspresso_shot!(test_document_highlight(
             test_case,
             &Position::default(),
+            None,
             None
         ));
     }
@@ -55,7 +56,8 @@ mod test {
         send_capabiltiies(&document_highlight_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_document_highlight(test_case.clone(), &Position::default(), None);
+        let test_result =
+            test_document_highlight(test_case.clone(), &Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -78,6 +80,7 @@ mod test {
         lspresso_shot!(test_document_highlight(
             test_case,
             &Position::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -92,7 +95,7 @@ mod test {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -101,6 +104,7 @@ mod test {
         lspresso_shot!(test_document_highlight(
             test_case,
             &Position::new(1, 9),
+            None,
             Some(&vec![DocumentHighlight {
                 range: Range {
                     start: Position::new(1, 8),

--- a/test-suite/src/document_link.rs
+++ b/test-suite/src/document_link.rs
@@ -36,7 +36,7 @@ mod test {
         send_capabiltiies(&document_link_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_link(test_case, None));
+        lspresso_shot!(test_document_link(test_case, None, None));
     }
 
     #[rstest]
@@ -53,7 +53,7 @@ mod test {
         send_capabiltiies(&document_link_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_document_link(test_case.clone(), None);
+        let test_result = test_document_link(test_case.clone(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -72,7 +72,7 @@ mod test {
         send_capabiltiies(&document_link_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_link(test_case, Some(&resp)));
+        lspresso_shot!(test_document_link(test_case, None, Some(&resp)));
     }
 
     // NOTE: rust-analyzer doesn't support `textDocument/documentLink`

--- a/test-suite/src/document_link_resolve.rs
+++ b/test-suite/src/document_link_resolve.rs
@@ -57,7 +57,7 @@ mod test {
             data: None,
         };
 
-        lspresso_shot!(test_document_link_resolve(test_case, &link, None));
+        lspresso_shot!(test_document_link_resolve(test_case, &link, None, None));
     }
 
     #[rstest]
@@ -94,7 +94,7 @@ mod test {
             data: None,
         };
 
-        let test_result = test_document_link_resolve(test_case.clone(), &link, None);
+        let test_result = test_document_link_resolve(test_case.clone(), &link, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -133,7 +133,12 @@ mod test {
             data: None,
         };
 
-        lspresso_shot!(test_document_link_resolve(test_case, &link, Some(&resp)));
+        lspresso_shot!(test_document_link_resolve(
+            test_case,
+            &link,
+            None,
+            Some(&resp)
+        ));
     }
 
     // NOTE: rust-analyzer doesn't support `documentLink/resolve`

--- a/test-suite/src/document_symbol.rs
+++ b/test-suite/src/document_symbol.rs
@@ -33,7 +33,7 @@ mod test {
         send_capabiltiies(&document_symbol_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_symbol(test_case, None));
+        lspresso_shot!(test_document_symbol(test_case, None, None));
     }
 
     #[rstest]
@@ -50,7 +50,7 @@ mod test {
         send_capabiltiies(&document_symbol_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_document_symbol(test_case.clone(), None);
+        let test_result = test_document_symbol(test_case.clone(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{syms:#?}"));
         if response_num == 1 {
@@ -83,7 +83,7 @@ mod test {
         send_capabiltiies(&document_symbol_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_document_symbol(test_case, Some(&syms)));
+        lspresso_shot!(test_document_symbol(test_case, None, Some(&syms)));
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod test {
         );
         let doc_sym_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -104,6 +104,7 @@ mod test {
 
         lspresso_shot!(test_document_symbol(
             doc_sym_test_case,
+            None,
             #[allow(deprecated)]
             Some(&DocumentSymbolResponse::Nested(vec![DocumentSymbol {
                 name: "main".to_string(),

--- a/test-suite/src/folding_range.rs
+++ b/test-suite/src/folding_range.rs
@@ -31,7 +31,7 @@ mod test {
         send_capabiltiies(&folding_range_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_folding_range(test_case, None));
+        lspresso_shot!(test_folding_range(test_case, None, None));
     }
 
     #[rstest]
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&folding_range_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_folding_range(test_case.clone(), None);
+        let test_result = test_folding_range(test_case.clone(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -67,7 +67,7 @@ mod test {
         send_capabiltiies(&folding_range_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_folding_range(test_case, Some(&resp)));
+        lspresso_shot!(test_folding_range(test_case, None, Some(&resp)));
     }
 
     #[test]
@@ -88,6 +88,7 @@ mod test {
 
         lspresso_shot!(test_folding_range(
             test_case,
+            None,
             Some(&vec![FoldingRange {
                 start_line: 0,
                 start_character: None,

--- a/test-suite/src/formatting.rs
+++ b/test-suite/src/formatting.rs
@@ -36,6 +36,7 @@ mod test {
         lspresso_shot!(test_formatting(
             test_case,
             None,
+            None,
             Some(&FormattingResult::EndState(contents.to_string()))
         ));
     }
@@ -51,7 +52,7 @@ mod test {
         send_capabiltiies(&formatting_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_formatting(test_case, None, None));
+        lspresso_shot!(test_formatting(test_case, None, None, None));
     }
 
     #[rstest]
@@ -68,7 +69,7 @@ mod test {
         send_capabiltiies(&formatting_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_formatting(test_case.clone(), None, None);
+        let test_result = test_formatting(test_case.clone(), None, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{edits:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -89,6 +90,7 @@ mod test {
 
         lspresso_shot!(test_formatting(
             test_case,
+            None,
             None,
             Some(&FormattingResult::Response(edits))
         ));
@@ -112,6 +114,7 @@ let foo = 5;
 
         lspresso_shot!(test_formatting(
             test_case,
+            None,
             None,
             Some(&FormattingResult::EndState(
                 "pub fn main() {
@@ -141,6 +144,7 @@ let foo = 5;
 
         lspresso_shot!(test_formatting(
             test_case,
+            None,
             None,
             Some(&FormattingResult::Response(vec![
                 TextEdit {

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_hover(test_case, &Position::default(), None));
+        lspresso_shot!(test_hover(test_case, &Position::default(), None, None));
     }
 
     #[rstest]
@@ -65,7 +65,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_hover(test_case.clone(), &Position::default(), None);
+        let test_result = test_hover(test_case.clone(), &Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -84,7 +84,12 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_hover(test_case, &Position::default(), Some(&resp)));
+        lspresso_shot!(test_hover(
+            test_case,
+            &Position::default(),
+            None,
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -106,6 +111,7 @@ mod test {
         lspresso_shot!(test_hover(
         test_case,
         &Position::new(1, 5),
+        None,
         Some(&Hover {
             range: Some(Range {
                 start: Position {

--- a/test-suite/src/implementation.rs
+++ b/test-suite/src/implementation.rs
@@ -33,7 +33,12 @@ mod test {
         send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_implementation(test_case, &Position::default(), None));
+        lspresso_shot!(test_implementation(
+            test_case,
+            &Position::default(),
+            None,
+            None
+        ));
     }
 
     #[rstest]
@@ -49,7 +54,7 @@ mod test {
         send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_implementation(test_case.clone(), &Position::default(), None);
+        let test_result = test_implementation(test_case.clone(), &Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -81,6 +86,7 @@ mod test {
         lspresso_shot!(test_implementation(
             test_case,
             &Position::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -108,7 +114,7 @@ pub fn main() {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -117,6 +123,7 @@ pub fn main() {
         lspresso_shot!(test_implementation(
             test_case,
             &Position::new(14, 10),
+            None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {

--- a/test-suite/src/incoming_calls.rs
+++ b/test-suite/src/incoming_calls.rs
@@ -63,6 +63,7 @@ mod test {
                 selection_range: Range::default(),
                 data: None
             },
+            None,
             None
         ));
     }
@@ -83,7 +84,7 @@ mod test {
 
         let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
-        let test_result = test_incoming_calls(test_case.clone(), &call_item, None);
+        let test_result = test_incoming_calls(test_case.clone(), &call_item, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -104,7 +105,12 @@ mod test {
 
         let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
-        lspresso_shot!(test_incoming_calls(test_case, &call_item, Some(&resp)));
+        lspresso_shot!(test_incoming_calls(
+            test_case,
+            &call_item,
+            None,
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -155,6 +161,7 @@ pub fn main() {
         lspresso_shot!(test_incoming_calls(
             test_case,
             &call_item,
+            None,
             Some(&vec![CallHierarchyIncomingCall {
                 from: CallHierarchyItem {
                     name: "main".to_string(),

--- a/test-suite/src/inlay_hint.rs
+++ b/test-suite/src/inlay_hint.rs
@@ -84,7 +84,7 @@ mod test {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))

--- a/test-suite/src/moniker.rs
+++ b/test-suite/src/moniker.rs
@@ -31,7 +31,7 @@ mod test {
         send_capabiltiies(&moniker_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_moniker(test_case, &Position::default(), None));
+        lspresso_shot!(test_moniker(test_case, &Position::default(), None, None));
     }
 
     #[rstest]
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&moniker_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_moniker(test_case.clone(), &Position::default(), None);
+        let test_result = test_moniker(test_case.clone(), &Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -67,7 +67,12 @@ mod test {
         send_capabiltiies(&moniker_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_moniker(test_case, &Position::default(), Some(&resp)));
+        lspresso_shot!(test_moniker(
+            test_case,
+            &Position::default(),
+            None,
+            Some(&resp)
+        ));
     }
 
     // NOTE: rust-analyzer doesn't support `textDocument/moniker` requests

--- a/test-suite/src/outgoing_calls.rs
+++ b/test-suite/src/outgoing_calls.rs
@@ -63,6 +63,7 @@ mod test {
                 selection_range: Range::default(),
                 data: None
             },
+            None,
             None
         ));
     }
@@ -83,7 +84,7 @@ mod test {
 
         let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
-        let test_result = test_outgoing_calls(test_case.clone(), &call_item, None);
+        let test_result = test_outgoing_calls(test_case.clone(), &call_item, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -104,7 +105,12 @@ mod test {
 
         let mut call_item = get_prepare_call_hierachy_response(1, &uri).unwrap()[0].clone();
         call_item.uri = get_full_dummy_source_path(&test_case);
-        lspresso_shot!(test_outgoing_calls(test_case, &call_item, Some(&resp)));
+        lspresso_shot!(test_outgoing_calls(
+            test_case,
+            &call_item,
+            None,
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -155,6 +161,7 @@ pub fn main() {
         lspresso_shot!(test_outgoing_calls(
             test_case,
             &call_item,
+            None,
             Some(&vec![CallHierarchyOutgoingCall {
                 to: CallHierarchyItem {
                     name: "foo".to_string(),

--- a/test-suite/src/prepare_call_hierarchy.rs
+++ b/test-suite/src/prepare_call_hierarchy.rs
@@ -40,6 +40,7 @@ mod test {
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
             &Position::default(),
+            None,
             None
         ));
     }
@@ -63,7 +64,7 @@ mod test {
         .expect("Failed to send capabilities");
 
         let test_result =
-            test_prepare_call_hierarchy(test_case.clone(), &Position::default(), None);
+            test_prepare_call_hierarchy(test_case.clone(), &Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -89,6 +90,7 @@ mod test {
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
             &Position::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -112,6 +114,7 @@ mod test {
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
             &Position::new(0, 8),
+            None,
             Some(&vec![CallHierarchyItem {
                 name: "main".to_string(),
                 kind: SymbolKind::FUNCTION,

--- a/test-suite/src/references.rs
+++ b/test-suite/src/references.rs
@@ -30,7 +30,13 @@ mod test {
         send_capabiltiies(&references_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_references(test_case, &Position::default(), true, None));
+        lspresso_shot!(test_references(
+            test_case,
+            &Position::default(),
+            true,
+            None,
+            None
+        ));
     }
 
     #[rstest]
@@ -46,7 +52,8 @@ mod test {
         send_capabiltiies(&references_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_references(test_case.clone(), &Position::default(), true, None);
+        let test_result =
+            test_references(test_case.clone(), &Position::default(), true, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{refs:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -68,6 +75,7 @@ mod test {
             test_case,
             &Position::default(),
             true,
+            None,
             Some(&refs)
         ));
     }
@@ -92,6 +100,7 @@ mod test {
             reference_test_case,
             &Position::new(1, 9),
             true,
+            None,
             Some(&vec![Location {
                 uri: Uri::from_str("src/main.rs").unwrap(),
                 range: Range {

--- a/test-suite/src/rename.rs
+++ b/test-suite/src/rename.rs
@@ -33,7 +33,7 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_rename(test_case, &Position::default(), "", None));
+        lspresso_shot!(test_rename(test_case, &Position::default(), "", None, None));
     }
 
     #[rstest]
@@ -49,7 +49,7 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_rename(test_case.clone(), &Position::default(), "", None);
+        let test_result = test_rename(test_case.clone(), &Position::default(), "", None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{edits:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -71,6 +71,7 @@ mod test {
             test_case,
             &Position::default(),
             "",
+            None,
             Some(&edits)
         ));
     }
@@ -85,7 +86,7 @@ mod test {
         );
         let rename_test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -95,6 +96,7 @@ mod test {
             rename_test_case,
             &Position::new(1, 9),
             "bar",
+            None,
             Some(&WorkspaceEdit {
                 changes: None,
                 document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {

--- a/test-suite/src/selection_range.rs
+++ b/test-suite/src/selection_range.rs
@@ -32,7 +32,7 @@ mod test {
         send_capabiltiies(&selection_range_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_selection_range(test_case, &Vec::new(), None));
+        lspresso_shot!(test_selection_range(test_case, &Vec::new(), None, None));
     }
 
     #[rstest]
@@ -50,7 +50,7 @@ mod test {
             .expect("Failed to send capabilities");
         let positions = vec![Position::default()];
 
-        let test_result = test_selection_range(test_case.clone(), &positions, None);
+        let test_result = test_selection_range(test_case.clone(), &positions, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -70,7 +70,12 @@ mod test {
             .expect("Failed to send capabilities");
         let positions = vec![Position::default(); 3];
 
-        lspresso_shot!(test_selection_range(test_case, &positions, Some(&resp)));
+        lspresso_shot!(test_selection_range(
+            test_case,
+            &positions,
+            None,
+            Some(&resp)
+        ));
     }
 
     #[test]
@@ -97,6 +102,7 @@ mod test {
         lspresso_shot!(test_selection_range(
             test_case,
             &positions,
+            None,
             Some(&vec![SelectionRange {
                 range: Range {
                     start: Position {

--- a/test-suite/src/semantic_tokens_full.rs
+++ b/test-suite/src/semantic_tokens_full.rs
@@ -46,7 +46,7 @@ mod test {
         send_capabiltiies(&semantic_tokens_full_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_semantic_tokens_full(test_case, None));
+        lspresso_shot!(test_semantic_tokens_full(test_case, None, None));
     }
 
     #[rstest]
@@ -64,7 +64,7 @@ mod test {
         send_response_num(response_num, &test_case_root).expect("Failed to send response num");
         send_capabiltiies(&semantic_tokens_full_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
-        let test_result = test_semantic_tokens_full(test_case.clone(), None);
+        let test_result = test_semantic_tokens_full(test_case.clone(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         match response_num {
@@ -124,7 +124,7 @@ mod test {
         send_capabiltiies(&semantic_tokens_full_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_semantic_tokens_full(test_case, Some(&resp)));
+        lspresso_shot!(test_semantic_tokens_full(test_case, None, Some(&resp)));
     }
 
     #[test]
@@ -166,6 +166,7 @@ mod test {
             ..
         })) = test_semantic_tokens_full(
             test_case.clone(),
+            None,
             Some(&SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: Some("4".to_string()),
                 data: expected_tokens.clone(),
@@ -174,6 +175,7 @@ mod test {
             if data != expected_tokens {
                 lspresso_shot!(test_semantic_tokens_full(
                     test_case,
+                    None,
                     Some(&SemanticTokensResult::Tokens(SemanticTokens {
                         result_id: Some("4".to_string()),
                         data: expected_tokens

--- a/test-suite/src/semantic_tokens_full_delta.rs
+++ b/test-suite/src/semantic_tokens_full_delta.rs
@@ -49,7 +49,7 @@ mod test {
         )
         .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_semantic_tokens_full_delta(test_case, None));
+        lspresso_shot!(test_semantic_tokens_full_delta(test_case, None, None));
     }
 
     #[rstest]
@@ -74,7 +74,7 @@ mod test {
             &test_case_root,
         )
         .expect("Failed to send capabilities");
-        let test_result = test_semantic_tokens_full_delta(test_case.clone(), None);
+        let test_result = test_semantic_tokens_full_delta(test_case.clone(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -103,7 +103,11 @@ mod test {
         )
         .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_semantic_tokens_full_delta(test_case, Some(&resp)));
+        lspresso_shot!(test_semantic_tokens_full_delta(
+            test_case,
+            None,
+            Some(&resp)
+        ));
     }
 
     #[ignore = "rust-analyzer behaves non-deterministically"]
@@ -172,6 +176,6 @@ mod test {
                 ],
             }),
         ];
-        lspresso_shot!(test_semantic_tokens_full_delta(test_case, None));
+        lspresso_shot!(test_semantic_tokens_full_delta(test_case, None, None));
     }
 }

--- a/test-suite/src/semantic_tokens_range.rs
+++ b/test-suite/src/semantic_tokens_range.rs
@@ -49,6 +49,7 @@ mod test {
         lspresso_shot!(test_semantic_tokens_range(
             test_case,
             &Range::default(),
+            None,
             None
         ));
     }
@@ -71,7 +72,8 @@ mod test {
             &test_case_root,
         )
         .expect("Failed to send capabilities");
-        let test_result = test_semantic_tokens_range(test_case.clone(), &Range::default(), None);
+        let test_result =
+            test_semantic_tokens_range(test_case.clone(), &Range::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
 
@@ -157,6 +159,7 @@ mod test {
         lspresso_shot!(test_semantic_tokens_range(
             test_case,
             &Range::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -213,13 +216,14 @@ mod test {
             end: Position::new(0, 10),
         };
         for result in &possible_results {
-            if test_semantic_tokens_range(test_case.clone(), &range, Some(result)).is_ok() {
+            if test_semantic_tokens_range(test_case.clone(), &range, None, Some(result)).is_ok() {
                 return;
             }
         }
         lspresso_shot!(test_semantic_tokens_range(
             test_case,
             &range,
+            None,
             Some(&possible_results[1]),
         ));
     }

--- a/test-suite/src/signature_help.rs
+++ b/test-suite/src/signature_help.rs
@@ -46,6 +46,7 @@ mod test {
             test_case,
             &Position::default(),
             None,
+            None,
             None
         ));
     }
@@ -65,7 +66,7 @@ mod test {
             .expect("Failed to send capabilities");
 
         let expected_err = TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
-        let test_result = test_signature_help(test_case, &Position::default(), None, None);
+        let test_result = test_signature_help(test_case, &Position::default(), None, None, None);
         assert_eq!(Err(expected_err), test_result);
     }
 
@@ -87,6 +88,7 @@ mod test {
             test_case,
             &Position::default(),
             None,
+            None,
             Some(&resp),
         ));
     }
@@ -102,7 +104,7 @@ pub fn main() {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -111,6 +113,7 @@ pub fn main() {
         lspresso_shot!(test_signature_help(
             test_case,
             &Position::new(2, 8),
+            None,
             None,
             Some(&SignatureHelp {
                 signatures: vec![SignatureInformation {

--- a/test-suite/src/type_definition.rs
+++ b/test-suite/src/type_definition.rs
@@ -33,7 +33,12 @@ mod test {
         send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_type_definition(test_case, &Position::default(), None));
+        lspresso_shot!(test_type_definition(
+            test_case,
+            &Position::default(),
+            None,
+            None
+        ));
     }
 
     #[rstest]
@@ -50,7 +55,7 @@ mod test {
         send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_type_definition(test_case.clone(), &Position::default(), None);
+        let test_result = test_type_definition(test_case.clone(), &Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -83,6 +88,7 @@ mod test {
         lspresso_shot!(test_type_definition(
             test_case,
             &Position::default(),
+            None,
             Some(&resp)
         ));
     }
@@ -101,7 +107,7 @@ pub fn main() {
         );
         let test_case = TestCase::new("rust-analyzer", source_file)
             .start_type(ServerStartType::Progress(
-                NonZeroU32::new(5).unwrap(),
+                NonZeroU32::new(4).unwrap(),
                 "rustAnalyzer/cachePriming".to_string(),
             ))
             .timeout(Duration::from_secs(20))
@@ -110,6 +116,7 @@ pub fn main() {
         lspresso_shot!(test_type_definition(
             test_case,
             &Position::new(5, 9),
+            None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),
                 origin_selection_range: Some(Range {


### PR DESCRIPTION
TODO: 
 -  [x] Update doc comments for all `test_*` functions, providing links to the spec and adding parameter descriptions where needed.
 - [x] Rip out the custom completion result logic. It's no longer needed now that we accept a custom comparator.