### PR TITLE
feat(lib): `textDocument/rangeFormatting`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ So far, we have:
 - [x] `textDocument/prepareCallHierarchy`
 - [x] `textDocument/prepareTypeHierarchy`
 - [x] `textDocument/publishDiagnostics`
+- [x] `textDocument/rangeFormatting`
 - [x] `textDocument/references`
 - [x] `textDocument/rename`
 - [x] `textDocument/selectionRange`

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -301,14 +301,14 @@ pub type CodeActionComparator = fn(&CodeActionResponse, &CodeActionResponse, &Te
 /// [`textDocument/codeAction`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction
 pub fn test_code_action(
     mut test_case: TestCase,
-    range: &Range,
+    range: Range,
     context: &CodeActionContext,
     cmp: Option<CodeActionComparator>,
     expected: Option<&CodeActionResponse>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::CodeAction);
     let range_json =
-        serde_json::to_string_pretty(range).expect("JSON deserialzation of `range` failed");
+        serde_json::to_string_pretty(&range).expect("JSON deserialzation of `range` failed");
     let context_json =
         serde_json::to_string_pretty(context).expect("JSON deserialzation of `params` failed");
 
@@ -547,16 +547,16 @@ pub type ColorPresentationComparator =
 /// [`textDocument/colorPresentation`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_colorPresentation
 pub fn test_color_presentation(
     mut test_case: TestCase,
-    color: &Color,
-    range: &Range,
+    color: Color,
+    range: Range,
     cmp: Option<ColorPresentationComparator>,
     expected: &Vec<ColorPresentation>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::ColorPresentation);
     let color_json =
-        serde_json::to_string_pretty(color).expect("JSON serialzation of `color` failed");
+        serde_json::to_string_pretty(&color).expect("JSON serialzation of `color` failed");
     let range_json =
-        serde_json::to_string_pretty(range).expect("JSON serialzation of `range` failed");
+        serde_json::to_string_pretty(&range).expect("JSON serialzation of `range` failed");
     collect_results(
         &test_case,
         &mut vec![
@@ -605,7 +605,7 @@ pub type CompletionComparator = fn(&CompletionResponse, &CompletionResponse, &Te
 /// [`textDocument/completion`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion
 pub fn test_completion(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<CompletionComparator>,
     expected: Option<&CompletionResponse>,
 ) -> TestResult<()> {
@@ -614,7 +614,7 @@ pub fn test_completion(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual| {
@@ -725,7 +725,7 @@ pub type DeclarationComparator =
 /// [`textDocument/declaration`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_declaration
 pub fn test_declaration(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<DeclarationComparator>,
     expected: Option<&GotoDeclarationResponse>,
 ) -> TestResult<()> {
@@ -734,7 +734,7 @@ pub fn test_declaration(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual| {
@@ -792,7 +792,7 @@ pub type DefinitionComparator =
 /// [`textDocument/definition`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition
 pub fn test_definition(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<DefinitionComparator>,
     expected: Option<&GotoDefinitionResponse>,
 ) -> TestResult<()> {
@@ -801,7 +801,7 @@ pub fn test_definition(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual| {
@@ -971,7 +971,7 @@ pub type DocumentHighlightComparator =
 /// [`textDocument/documentHighlight`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight
 pub fn test_document_highlight(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<DocumentHighlightComparator>,
     expected: Option<&Vec<DocumentHighlight>>,
 ) -> TestResult<()> {
@@ -980,7 +980,7 @@ pub fn test_document_highlight(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual: &Vec<DocumentHighlight>| {
@@ -1348,7 +1348,7 @@ pub type HoverComparator = fn(&Hover, &Hover, &TestCase) -> bool;
 /// [`textDocument/hover`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
 pub fn test_hover(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<HoverComparator>,
     expected: Option<&Hover>,
 ) -> TestResult<()> {
@@ -1357,7 +1357,7 @@ pub fn test_hover(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual| {
@@ -1395,7 +1395,7 @@ pub type ImplementationComparator =
 /// [`textDocument/implementation`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_implementation
 pub fn test_implementation(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<ImplementationComparator>,
     expected: Option<&GotoImplementationResponse>,
 ) -> TestResult<()> {
@@ -1404,7 +1404,7 @@ pub fn test_implementation(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual| {
@@ -1518,13 +1518,13 @@ pub type InlayHintComparator = fn(&Vec<InlayHint>, &Vec<InlayHint>, &TestCase) -
 /// [`textDocument/inlayHint`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint
 pub fn test_inlay_hint(
     mut test_case: TestCase,
-    range: &Range,
+    range: Range,
     cmp: Option<InlayHintComparator>,
     expected: Option<&Vec<InlayHint>>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::InlayHint);
     let range_json =
-        serde_json::to_string_pretty(range).expect("JSON serialzation of `range` failed");
+        serde_json::to_string_pretty(&range).expect("JSON serialzation of `range` failed");
     collect_results(
         &test_case,
         &mut vec![
@@ -1573,7 +1573,7 @@ pub type MonikerComparator = fn(&Vec<Moniker>, &Vec<Moniker>, &TestCase) -> bool
 /// [`textDocument/moniker`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_moniker
 pub fn test_moniker(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<MonikerComparator>,
     expected: Option<&Vec<Moniker>>,
 ) -> TestResult<()> {
@@ -1582,7 +1582,7 @@ pub fn test_moniker(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual: &Vec<Moniker>| {
@@ -1672,7 +1672,7 @@ pub type PrepareCallHierarchyComparator =
 /// [`textDocument/prepareCallHierarchy`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy
 pub fn test_prepare_call_hierarchy(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<PrepareCallHierarchyComparator>,
     expected: Option<&Vec<CallHierarchyItem>>,
 ) -> TestResult<()> {
@@ -1681,7 +1681,7 @@ pub fn test_prepare_call_hierarchy(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual: &Vec<CallHierarchyItem>| {
@@ -1726,7 +1726,7 @@ pub type PrepareTypeHierarchyComparator =
 /// [`textDocument/prepareTypeHierarchy`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareTypeHierarchy
 pub fn test_prepare_type_hierarchy(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     items: Option<&Vec<TypeHierarchyItem>>,
     cmp: Option<PrepareTypeHierarchyComparator>,
     expected: Option<&Vec<TypeHierarchyItem>>,
@@ -1744,7 +1744,7 @@ pub fn test_prepare_type_hierarchy(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
             LuaReplacement::Other {
                 from: "items",
                 to: items_json,
@@ -1855,14 +1855,14 @@ pub type RangeFormattingComparator = fn(&Vec<TextEdit>, &Vec<TextEdit>, &TestCas
 /// [`textDocument/rangeFormatting`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rangeFormatting
 pub fn test_range_formatting(
     mut test_case: TestCase,
-    range: &Range,
+    range: Range,
     options: Option<&FormattingOptions>,
     cmp: Option<RangeFormattingComparator>,
     expected: Option<&Vec<TextEdit>>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::RangeFormatting);
     let range_json =
-        serde_json::to_string_pretty(range).expect("JSON deserialzation of `range` failed");
+        serde_json::to_string_pretty(&range).expect("JSON deserialzation of `range` failed");
     let options_json = options
         .map_or_else(
             || serde_json::to_string_pretty(&default_format_opts()),
@@ -1922,7 +1922,7 @@ pub type ReferencesComparator = fn(&Vec<Location>, &Vec<Location>, &TestCase) ->
 /// [`textDocument/references`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_references
 pub fn test_references(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     include_declaration: bool,
     cmp: Option<ReferencesComparator>,
     expected: Option<&Vec<Location>>,
@@ -1934,7 +1934,7 @@ pub fn test_references(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
             LuaReplacement::ParamNested {
                 name: "context",
                 fields: vec![LuaReplacement::ParamDirect {
@@ -1983,7 +1983,7 @@ pub type RenameComparator = fn(&WorkspaceEdit, &WorkspaceEdit, &TestCase) -> boo
 /// [`textDocument/rename`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename
 pub fn test_rename(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     new_name: &str,
     cmp: Option<RenameComparator>,
     expected: Option<&WorkspaceEdit>,
@@ -1995,7 +1995,7 @@ pub fn test_rename(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
             LuaReplacement::ParamDirect {
                 name: "newName",
                 json: new_name_json,
@@ -2294,13 +2294,13 @@ pub type SemanticTokensRangeComparator =
 /// [`textDocument/semanticTokens/range`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_rangeRequest
 pub fn test_semantic_tokens_range(
     mut test_case: TestCase,
-    range: &Range,
+    range: Range,
     cmp: Option<SemanticTokensRangeComparator>,
     expected: Option<&SemanticTokensRangeResult>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::SemanticTokensRange);
     let range_json =
-        serde_json::to_string_pretty(range).expect("JSON deserialzation of range failed");
+        serde_json::to_string_pretty(&range).expect("JSON deserialzation of range failed");
     collect_results(
         &test_case,
         &mut vec![
@@ -2361,7 +2361,7 @@ pub fn test_semantic_tokens_range(
     )
 }
 
-pub type SeignatureHelpComparator = fn(&SignatureHelp, &SignatureHelp, &TestCase) -> bool;
+pub type SignatureHelpComparator = fn(&SignatureHelp, &SignatureHelp, &TestCase) -> bool;
 
 /// Tests the server's response to a [`textDocument/signatureHelp`] request
 ///
@@ -2383,9 +2383,9 @@ pub type SeignatureHelpComparator = fn(&SignatureHelp, &SignatureHelp, &TestCase
 /// [`textDocument/signatureHelp`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp
 pub fn test_signature_help(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     context: Option<&SignatureHelpContext>,
-    cmp: Option<SeignatureHelpComparator>,
+    cmp: Option<SignatureHelpComparator>,
     expected: Option<&SignatureHelp>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::SignatureHelp);
@@ -2400,7 +2400,7 @@ pub fn test_signature_help(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
             LuaReplacement::ParamDirect {
                 name: "context",
                 json: context_json,
@@ -2442,7 +2442,7 @@ pub type TypeDefinitionComparator =
 /// [`textDocument/typeDefinition`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_typeDefinition
 pub fn test_type_definition(
     mut test_case: TestCase,
-    cursor_pos: &Position,
+    cursor_pos: Position,
     cmp: Option<TypeDefinitionComparator>,
     expected: Option<&GotoTypeDefinitionResponse>,
 ) -> TestResult<()> {
@@ -2451,7 +2451,7 @@ pub fn test_type_definition(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(*cursor_pos),
+            LuaReplacement::ParamPosition(cursor_pos),
         ],
         expected,
         |expected, actual| {
@@ -2514,7 +2514,7 @@ pub type WorkspaceDiagnosticComparator =
 /// [`workspace/diagnostic`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_diagnostic
 pub fn test_workspace_diagnostic(
     mut test_case: TestCase,
-    identifier: Option<String>,
+    identifier: Option<&str>,
     previous_result_ids: &Vec<PreviousResultId>,
     cmp: Option<WorkspaceDiagnosticComparator>,
     expected: &WorkspaceDiagnosticReport,
@@ -2522,7 +2522,7 @@ pub fn test_workspace_diagnostic(
     test_case.test_type = Some(TestType::WorkspaceDiagnostic);
     let identifier_json = identifier.map_or_else(
         || "null".to_string(), // NOTE: `vim.json.decode()` fails with an empty string
-        |id| serde_json::to_string_pretty(&id).expect("JSON deserialzation of identifier failed"),
+        |id| serde_json::to_string_pretty(id).expect("JSON deserialzation of identifier failed"),
     );
     let previous_result_ids_json = serde_json::to_string_pretty(previous_result_ids)
         .expect("JSON deserialzation of previous result id failed");

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -296,7 +296,7 @@ pub type CodeActionComparator = fn(&CodeActionResponse, &CodeActionResponse, &Te
 ///
 /// # Panics
 ///
-/// Panics if JSON serialization of `range` or `context` fails
+/// Panics if JSON serialization of `context` fails
 ///
 /// [`textDocument/codeAction`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction
 pub fn test_code_action(
@@ -307,8 +307,6 @@ pub fn test_code_action(
     expected: Option<&CodeActionResponse>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::CodeAction);
-    let range_json =
-        serde_json::to_string_pretty(&range).expect("JSON deserialzation of `range` failed");
     let context_json =
         serde_json::to_string_pretty(context).expect("JSON deserialzation of `params` failed");
 
@@ -316,10 +314,7 @@ pub fn test_code_action(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamDirect {
-                name: "range",
-                json: range_json,
-            },
+            LuaReplacement::ParamRange(range),
             LuaReplacement::ParamDirect {
                 name: "context",
                 json: context_json,
@@ -542,7 +537,7 @@ pub type ColorPresentationComparator =
 ///
 /// # Panics
 ///
-/// Panics if JSON serialization of `color` or `range` fails
+/// Panics if JSON serialization of `color` fails
 ///
 /// [`textDocument/colorPresentation`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_colorPresentation
 pub fn test_color_presentation(
@@ -555,8 +550,6 @@ pub fn test_color_presentation(
     test_case.test_type = Some(TestType::ColorPresentation);
     let color_json =
         serde_json::to_string_pretty(&color).expect("JSON serialzation of `color` failed");
-    let range_json =
-        serde_json::to_string_pretty(&range).expect("JSON serialzation of `range` failed");
     collect_results(
         &test_case,
         &mut vec![
@@ -565,10 +558,7 @@ pub fn test_color_presentation(
                 name: "color",
                 json: color_json,
             },
-            LuaReplacement::ParamDirect {
-                name: "range",
-                json: range_json,
-            },
+            LuaReplacement::ParamRange(range),
         ],
         Some(expected),
         |expected, actual: &Vec<ColorPresentation>| {
@@ -614,7 +604,10 @@ pub fn test_completion(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual| {
@@ -734,7 +727,10 @@ pub fn test_declaration(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual| {
@@ -801,7 +797,10 @@ pub fn test_definition(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual| {
@@ -980,7 +979,10 @@ pub fn test_document_highlight(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual: &Vec<DocumentHighlight>| {
@@ -1357,7 +1359,10 @@ pub fn test_hover(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual| {
@@ -1404,7 +1409,10 @@ pub fn test_implementation(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual| {
@@ -1511,10 +1519,6 @@ pub type InlayHintComparator = fn(&Vec<InlayHint>, &Vec<InlayHint>, &TestCase) -
 /// Returns [`TestError`] if the test case is invalid, the expected results don't match,
 /// or some other failure occurs
 ///
-/// # Panics
-///
-/// Panics if JSON serialization of `range` fails
-///
 /// [`textDocument/inlayHint`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint
 pub fn test_inlay_hint(
     mut test_case: TestCase,
@@ -1523,16 +1527,11 @@ pub fn test_inlay_hint(
     expected: Option<&Vec<InlayHint>>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::InlayHint);
-    let range_json =
-        serde_json::to_string_pretty(&range).expect("JSON serialzation of `range` failed");
     collect_results(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamDirect {
-                name: "range",
-                json: range_json,
-            },
+            LuaReplacement::ParamRange(range),
         ],
         expected,
         |expected, actual: &Vec<InlayHint>| {
@@ -1582,7 +1581,10 @@ pub fn test_moniker(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual: &Vec<Moniker>| {
@@ -1681,7 +1683,10 @@ pub fn test_prepare_call_hierarchy(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual: &Vec<CallHierarchyItem>| {
@@ -1744,7 +1749,10 @@ pub fn test_prepare_type_hierarchy(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
             LuaReplacement::Other {
                 from: "items",
                 to: items_json,
@@ -1850,7 +1858,7 @@ pub type RangeFormattingComparator = fn(&Vec<TextEdit>, &Vec<TextEdit>, &TestCas
 ///
 /// # Panics
 ///
-/// Panics if JSON serialization of `range` or `options` fails
+/// Panics if JSON serialization of `options` fails
 ///
 /// [`textDocument/rangeFormatting`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rangeFormatting
 pub fn test_range_formatting(
@@ -1861,8 +1869,6 @@ pub fn test_range_formatting(
     expected: Option<&Vec<TextEdit>>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::RangeFormatting);
-    let range_json =
-        serde_json::to_string_pretty(&range).expect("JSON deserialzation of `range` failed");
     let options_json = options
         .map_or_else(
             || serde_json::to_string_pretty(&default_format_opts()),
@@ -1873,10 +1879,7 @@ pub fn test_range_formatting(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamDirect {
-                name: "range",
-                json: range_json,
-            },
+            LuaReplacement::ParamRange(range),
             LuaReplacement::ParamDirect {
                 name: "options",
                 json: options_json,
@@ -1934,7 +1937,10 @@ pub fn test_references(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
             LuaReplacement::ParamNested {
                 name: "context",
                 fields: vec![LuaReplacement::ParamDirect {
@@ -1995,7 +2001,10 @@ pub fn test_rename(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
             LuaReplacement::ParamDirect {
                 name: "newName",
                 json: new_name_json,
@@ -2287,10 +2296,6 @@ pub type SemanticTokensRangeComparator =
 /// Returns [`TestError`] if the test case is invalid, the expected results don't match,
 /// or some other failure occurs
 ///
-/// # Panics
-///
-/// Panics if JSON serialization of `range` fails
-///
 /// [`textDocument/semanticTokens/range`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_rangeRequest
 pub fn test_semantic_tokens_range(
     mut test_case: TestCase,
@@ -2299,16 +2304,11 @@ pub fn test_semantic_tokens_range(
     expected: Option<&SemanticTokensRangeResult>,
 ) -> TestResult<()> {
     test_case.test_type = Some(TestType::SemanticTokensRange);
-    let range_json =
-        serde_json::to_string_pretty(&range).expect("JSON deserialzation of range failed");
     collect_results(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamDirect {
-                name: "range",
-                json: range_json,
-            },
+            LuaReplacement::ParamRange(range),
         ],
         expected,
         |expected, actual| {
@@ -2400,7 +2400,10 @@ pub fn test_signature_help(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
             LuaReplacement::ParamDirect {
                 name: "context",
                 json: context_json,
@@ -2451,7 +2454,10 @@ pub fn test_type_definition(
         &test_case,
         &mut vec![
             LuaReplacement::ParamTextDocument,
-            LuaReplacement::ParamPosition(cursor_pos),
+            LuaReplacement::ParamPosition {
+                pos: cursor_pos,
+                name: None,
+            },
         ],
         expected,
         |expected, actual| {

--- a/lspresso-shot/types/formatting.rs
+++ b/lspresso-shot/types/formatting.rs
@@ -32,3 +32,21 @@ impl std::fmt::Display for FormattingMismatchError {
         write_fields_comparison(f, "FormattingResult", &self.expected, &self.actual, 0)
     }
 }
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct RangeFormattingMismatchError {
+    pub test_id: String,
+    pub expected: Vec<TextEdit>,
+    pub actual: Vec<TextEdit>,
+}
+
+impl std::fmt::Display for RangeFormattingMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Range Formatting response:",
+            self.test_id
+        )?;
+        write_fields_comparison(f, "Vec<TextEdit>", &self.expected, &self.actual, 0)
+    }
+}

--- a/lspresso-shot/types/mod.rs
+++ b/lspresso-shot/types/mod.rs
@@ -73,6 +73,7 @@ use std::{
 use code_action::CodeActionResolveMismatchError;
 use color_presentation::ColorPresentationMismatchError;
 use document_color::DocumentColorMismatchError;
+use formatting::RangeFormattingMismatchError;
 use inlay_hint::InlayHintMismatchError;
 use lsp_types::{Position, Uri};
 use rand::distr::Distribution as _;
@@ -135,6 +136,8 @@ pub enum TestType {
     PrepareTypeHierarchy,
     /// Test `textDocument/publishDiagnostics` requests
     PublishDiagnostics,
+    /// Test `textDocument/rangeFormatting` requests
+    RangeFormatting,
     /// Test `textDocument/references` requests
     References,
     /// Test `textDocument/rename` requests
@@ -187,6 +190,7 @@ impl std::fmt::Display for TestType {
                 Self::PrepareCallHierarchy => "textDocument/prepareCallHierarchy",
                 Self::PrepareTypeHierarchy => "textDocument/prepareTypeHierarchy",
                 Self::PublishDiagnostics => "textDocument/publishDiagnostics",
+                Self::RangeFormatting => "textDocument/rangeFormatting",
                 Self::References => "textDocument/references",
                 Self::Rename => "textDocument/rename",
                 Self::SelectionRange => "textDocument/selectionRange",
@@ -702,6 +706,8 @@ pub enum TestError {
     PrepareCallHierarchyMismatch(#[from] PrepareCallHierachyMismatchError),
     #[error(transparent)]
     PrepareTypeHierarchyMismatch(#[from] PrepareTypeHierarchyMismatchError),
+    #[error(transparent)]
+    RangeFormattingMismatch(#[from] RangeFormattingMismatchError),
     #[error(transparent)]
     ReferencesMismatch(#[from] ReferencesMismatchError),
     #[error(transparent)]

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -8,10 +8,11 @@ use lsp_types::{
     CodeAction, CodeActionParams, CodeLens, CodeLensParams, ColorPresentationParams,
     CompletionItem, CompletionParams, DocumentColorParams, DocumentDiagnosticParams,
     DocumentFormattingParams, DocumentHighlightParams, DocumentLink, DocumentLinkParams,
-    DocumentSymbolParams, FoldingRangeParams, GotoDefinitionParams, HoverParams, InlayHintParams,
-    MonikerParams, ReferenceParams, RenameParams, SelectionRangeParams, SemanticTokensDeltaParams,
-    SemanticTokensParams, SemanticTokensRangeParams, ServerCapabilities, SignatureHelpParams,
-    TypeHierarchyPrepareParams, Uri, WorkspaceDiagnosticParams,
+    DocumentRangeFormattingParams, DocumentSymbolParams, FoldingRangeParams, GotoDefinitionParams,
+    HoverParams, InlayHintParams, MonikerParams, ReferenceParams, RenameParams,
+    SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensParams,
+    SemanticTokensRangeParams, ServerCapabilities, SignatureHelpParams, TypeHierarchyPrepareParams,
+    Uri, WorkspaceDiagnosticParams,
     notification::{DidOpenTextDocument, Notification as _, PublishDiagnostics},
     request::{
         CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
@@ -20,8 +21,8 @@ use lsp_types::{
         DocumentHighlightRequest, DocumentLinkRequest, DocumentLinkResolve, DocumentSymbolRequest,
         FoldingRangeRequest, Formatting, GotoDeclaration, GotoDeclarationParams, GotoDefinition,
         GotoImplementation, GotoImplementationParams, GotoTypeDefinition, GotoTypeDefinitionParams,
-        HoverRequest, InlayHintRequest, MonikerRequest, References, Rename, Request as _,
-        ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullDeltaRequest,
+        HoverRequest, InlayHintRequest, MonikerRequest, RangeFormatting, References, Rename,
+        Request as _, ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullDeltaRequest,
         SemanticTokensFullRequest, SemanticTokensRangeRequest, SignatureHelpRequest,
         TypeHierarchyPrepare, WorkspaceDiagnosticRequest,
     },
@@ -35,15 +36,15 @@ use crate::{
         get_completion_response, get_declaration_response, get_definition_response,
         get_diagnostic_response, get_document_color_response, get_document_highlight_response,
         get_document_link_resolve_response, get_document_link_response,
-        get_document_symbol_response, get_folding_range_response, get_formatting_response,
-        get_hover_response, get_implementation_response, get_incoming_calls_response,
-        get_inlay_hint_response, get_moniker_response, get_outgoing_calls_response,
-        get_prepare_call_hierachy_response, get_prepare_type_hierachy_response,
-        get_publish_diagnostics_response, get_references_response, get_rename_response,
-        get_selection_range_response, get_semantic_tokens_full_delta_response,
-        get_semantic_tokens_full_response, get_semantic_tokens_range_response,
-        get_signature_help_response, get_type_definition_response,
-        get_workspace_diagnostics_response,
+        get_document_symbol_response, get_folding_range_response, get_formatting_range_response,
+        get_formatting_response, get_hover_response, get_implementation_response,
+        get_incoming_calls_response, get_inlay_hint_response, get_moniker_response,
+        get_outgoing_calls_response, get_prepare_call_hierachy_response,
+        get_prepare_type_hierachy_response, get_publish_diagnostics_response,
+        get_references_response, get_rename_response, get_selection_range_response,
+        get_semantic_tokens_full_delta_response, get_semantic_tokens_full_response,
+        get_semantic_tokens_range_response, get_signature_help_response,
+        get_type_definition_response, get_workspace_diagnostics_response,
     },
 };
 
@@ -368,6 +369,15 @@ pub fn handle_request(
                 req,
                 conn,
                 |params: DocumentFormattingParams| -> Uri { params.text_document.uri }
+            )?;
+        }
+        RangeFormatting::METHOD => {
+            handle_request!(
+                RangeFormatting,
+                get_formatting_range_response,
+                req,
+                conn,
+                |params: DocumentRangeFormattingParams| -> Uri { params.text_document.uri }
             )?;
         }
         GotoDeclaration::METHOD => {

--- a/test-server/src/responses.rs
+++ b/test-server/src/responses.rs
@@ -1801,3 +1801,12 @@ pub fn get_formatting_response(response_num: u32, uri: &Uri) -> Option<Vec<TextE
         _ => None,
     }
 }
+
+/// For use with `test_formatting`.
+/// Since `textDocument/formatting` and `textDocument/formattingRange` have the
+/// same response, this just wraps `get_formatting_response`.
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn get_formatting_range_response(response_num: u32, uri: &Uri) -> Option<Vec<TextEdit>> {
+    get_formatting_response(response_num, uri)
+}

--- a/test-suite/src/code_action.rs
+++ b/test-suite/src/code_action.rs
@@ -49,7 +49,7 @@ mod test {
 
         lspresso_shot!(test_code_action(
             test_case,
-            &Range::default(),
+            Range::default(),
             &CodeActionContext::default(),
             None,
             None
@@ -74,7 +74,7 @@ mod test {
 
         let test_result = test_code_action(
             test_case.clone(),
-            &Range::default(),
+            Range::default(),
             &CodeActionContext::default(),
             None,
             None,
@@ -101,7 +101,7 @@ mod test {
 
         lspresso_shot!(test_code_action(
             test_case,
-            &Range::default(),
+            Range::default(),
             &CodeActionContext::default(),
             None,
             Some(&resp)
@@ -255,7 +255,7 @@ mod test {
 
         lspresso_shot!(test_code_action(
             test_case,
-            &range,
+            range,
             &CodeActionContext::default(),
             Some(cmp),
             Some(&vec![

--- a/test-suite/src/color_presentation.rs
+++ b/test-suite/src/color_presentation.rs
@@ -43,8 +43,8 @@ mod test {
 
         lspresso_shot!(test_color_presentation(
             test_case,
-            &color,
-            &Range::default(),
+            color,
+            Range::default(),
             None,
             &resp
         ));

--- a/test-suite/src/completion.rs
+++ b/test-suite/src/completion.rs
@@ -45,7 +45,7 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_completion(test_case, &Position::default(), None, None));
+        lspresso_shot!(test_completion(test_case, Position::default(), None, None));
     }
 
     #[rstest]
@@ -61,7 +61,7 @@ mod test {
         send_capabiltiies(&completion_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_completion(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_completion(test_case.clone(), Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -81,7 +81,7 @@ mod test {
 
         lspresso_shot!(test_completion(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -211,7 +211,7 @@ println!("format {local_variable} arguments");
 
         lspresso_shot!(test_completion(
             test_case,
-            &Position::new(1, 9),
+            Position::new(1, 9),
             Some(cmp),
             Some(&expected_item)
         ));

--- a/test-suite/src/declaration.rs
+++ b/test-suite/src/declaration.rs
@@ -33,12 +33,7 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_declaration(
-            test_case,
-            &Position::default(),
-            None,
-            None
-        ));
+        lspresso_shot!(test_declaration(test_case, Position::default(), None, None));
     }
 
     #[rstest]
@@ -54,7 +49,7 @@ mod test {
         send_capabiltiies(&declaration_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_declaration(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_declaration(test_case.clone(), Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -85,7 +80,7 @@ mod test {
 
         lspresso_shot!(test_declaration(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -110,7 +105,7 @@ mod test {
 
         lspresso_shot!(test_declaration(
             test_case,
-            &Position::new(2, 5),
+            Position::new(2, 5),
             None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),

--- a/test-suite/src/definition.rs
+++ b/test-suite/src/definition.rs
@@ -32,7 +32,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_definition(test_case, &Position::default(), None, None));
+        lspresso_shot!(test_definition(test_case, Position::default(), None, None));
     }
 
     #[rstest]
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_definition(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_definition(test_case.clone(), Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -79,7 +79,7 @@ mod test {
 
         lspresso_shot!(test_definition(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -104,7 +104,7 @@ mod test {
 
         lspresso_shot!(test_definition(
             test_case,
-            &Position::new(2, 5),
+            Position::new(2, 5),
             None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),

--- a/test-suite/src/diagnostics.rs
+++ b/test-suite/src/diagnostics.rs
@@ -113,7 +113,7 @@ mod tests {
 
         lspresso_shot!(test_workspace_diagnostic(
             test_case,
-            Some(path),
+            Some(&path),
             &Vec::new(),
             None,
             &resp

--- a/test-suite/src/document_highlight.rs
+++ b/test-suite/src/document_highlight.rs
@@ -33,7 +33,7 @@ mod test {
 
         lspresso_shot!(test_document_highlight(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None
         ));
@@ -55,7 +55,7 @@ mod test {
             .expect("Failed to send capabilities");
 
         let test_result =
-            test_document_highlight(test_case.clone(), &Position::default(), None, None);
+            test_document_highlight(test_case.clone(), Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -77,7 +77,7 @@ mod test {
 
         lspresso_shot!(test_document_highlight(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -101,7 +101,7 @@ mod test {
 
         lspresso_shot!(test_document_highlight(
             test_case,
-            &Position::new(1, 9),
+            Position::new(1, 9),
             None,
             Some(&vec![DocumentHighlight {
                 range: Range {

--- a/test-suite/src/formatting.rs
+++ b/test-suite/src/formatting.rs
@@ -4,7 +4,7 @@ mod test {
 
     use crate::test_helpers::{NON_RESPONSE_NUM, cargo_dot_toml};
     use lspresso_shot::{
-        lspresso_shot, test_formatting,
+        lspresso_shot, test_formatting, test_range_formatting,
         types::{ServerStartType, TestCase, TestError, TestFile, formatting::FormattingResult},
     };
     use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
@@ -15,6 +15,13 @@ mod test {
     fn formatting_capabilities_simple() -> ServerCapabilities {
         ServerCapabilities {
             document_formatting_provider: Some(OneOf::Left(true)),
+            ..Default::default()
+        }
+    }
+
+    fn range_formatting_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            document_range_formatting_provider: Some(OneOf::Left(true)),
             ..Default::default()
         }
     }
@@ -55,6 +62,26 @@ mod test {
         lspresso_shot!(test_formatting(test_case, None, None, None));
     }
 
+    #[test]
+    fn test_server_range_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&range_formatting_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_range_formatting(
+            test_case,
+            &Range::default(),
+            None,
+            None,
+            None,
+        ));
+    }
+
     #[rstest]
     fn test_server_response_simple_expect_none_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
         let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
@@ -93,6 +120,30 @@ mod test {
             None,
             None,
             Some(&FormattingResult::Response(edits))
+        ));
+    }
+
+    #[rstest]
+    fn test_server_range_simple_expect_some_got_some(#[values(0, 1, 2, 3)] response_num: u32) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let edits =
+            test_server::responses::get_formatting_range_response(response_num, &uri).unwrap();
+        let source_file =
+            TestFile::new(test_server::get_dummy_source_path(), "Some source contents");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&range_formatting_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_range_formatting(
+            test_case,
+            &Range::default(),
+            None,
+            None,
+            Some(&edits)
         ));
     }
 
@@ -164,4 +215,6 @@ let foo = 5;
             ])),
         ));
     }
+
+    // NOTE: rust-analyzer doesn't support `textDocument/rangeFormatting` requests
 }

--- a/test-suite/src/formatting.rs
+++ b/test-suite/src/formatting.rs
@@ -75,7 +75,7 @@ mod test {
 
         lspresso_shot!(test_range_formatting(
             test_case,
-            &Range::default(),
+            Range::default(),
             None,
             None,
             None,
@@ -140,7 +140,7 @@ mod test {
 
         lspresso_shot!(test_range_formatting(
             test_case,
-            &Range::default(),
+            Range::default(),
             None,
             None,
             Some(&edits)

--- a/test-suite/src/hover.rs
+++ b/test-suite/src/hover.rs
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_hover(test_case, &Position::default(), None, None));
+        lspresso_shot!(test_hover(test_case, Position::default(), None, None));
     }
 
     #[rstest]
@@ -65,7 +65,7 @@ mod test {
         send_capabiltiies(&hover_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_hover(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_hover(test_case.clone(), Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -86,7 +86,7 @@ mod test {
 
         lspresso_shot!(test_hover(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -110,7 +110,7 @@ mod test {
 
         lspresso_shot!(test_hover(
         test_case,
-        &Position::new(1, 5),
+        Position::new(1, 5),
         None,
         Some(&Hover {
             range: Some(Range {

--- a/test-suite/src/implementation.rs
+++ b/test-suite/src/implementation.rs
@@ -35,7 +35,7 @@ mod test {
 
         lspresso_shot!(test_implementation(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None
         ));
@@ -54,7 +54,7 @@ mod test {
         send_capabiltiies(&implementation_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_implementation(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_implementation(test_case.clone(), Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -85,7 +85,7 @@ mod test {
 
         lspresso_shot!(test_implementation(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -122,7 +122,7 @@ pub fn main() {
 
         lspresso_shot!(test_implementation(
             test_case,
-            &Position::new(14, 10),
+            Position::new(14, 10),
             None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),

--- a/test-suite/src/inlay_hint.rs
+++ b/test-suite/src/inlay_hint.rs
@@ -32,7 +32,7 @@ mod test {
         send_capabiltiies(&inlay_hint_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_inlay_hint(test_case, &Range::default(), None, None));
+        lspresso_shot!(test_inlay_hint(test_case, Range::default(), None, None));
     }
 
     #[rstest]
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&inlay_hint_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_inlay_hint(test_case.clone(), &Range::default(), None, None);
+        let test_result = test_inlay_hint(test_case.clone(), Range::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -68,7 +68,7 @@ mod test {
 
         lspresso_shot!(test_inlay_hint(
             test_case,
-            &Range::default(),
+            Range::default(),
             None,
             Some(&resp)
         ));
@@ -124,7 +124,7 @@ mod test {
 
         lspresso_shot!(test_inlay_hint(
             test_case,
-            &Range::new(
+            Range::new(
                 Position {
                     line: 0,
                     character: 0,

--- a/test-suite/src/moniker.rs
+++ b/test-suite/src/moniker.rs
@@ -31,7 +31,7 @@ mod test {
         send_capabiltiies(&moniker_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_moniker(test_case, &Position::default(), None, None));
+        lspresso_shot!(test_moniker(test_case, Position::default(), None, None));
     }
 
     #[rstest]
@@ -48,7 +48,7 @@ mod test {
         send_capabiltiies(&moniker_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_moniker(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_moniker(test_case.clone(), Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -69,7 +69,7 @@ mod test {
 
         lspresso_shot!(test_moniker(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));

--- a/test-suite/src/prepare_call_hierarchy.rs
+++ b/test-suite/src/prepare_call_hierarchy.rs
@@ -39,7 +39,7 @@ mod test {
 
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None
         ));
@@ -64,7 +64,7 @@ mod test {
         .expect("Failed to send capabilities");
 
         let test_result =
-            test_prepare_call_hierarchy(test_case.clone(), &Position::default(), None, None);
+            test_prepare_call_hierarchy(test_case.clone(), Position::default(), None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -89,7 +89,7 @@ mod test {
 
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -113,7 +113,7 @@ mod test {
 
         lspresso_shot!(test_prepare_call_hierarchy(
             test_case,
-            &Position::new(0, 8),
+            Position::new(0, 8),
             None,
             Some(&vec![CallHierarchyItem {
                 name: "main".to_string(),

--- a/test-suite/src/references.rs
+++ b/test-suite/src/references.rs
@@ -32,7 +32,7 @@ mod test {
 
         lspresso_shot!(test_references(
             test_case,
-            &Position::default(),
+            Position::default(),
             true,
             None,
             None
@@ -52,8 +52,7 @@ mod test {
         send_capabiltiies(&references_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result =
-            test_references(test_case.clone(), &Position::default(), true, None, None);
+        let test_result = test_references(test_case.clone(), Position::default(), true, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{refs:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -73,7 +72,7 @@ mod test {
 
         lspresso_shot!(test_references(
             test_case,
-            &Position::default(),
+            Position::default(),
             true,
             None,
             Some(&refs)
@@ -98,7 +97,7 @@ mod test {
 
         lspresso_shot!(test_references(
             reference_test_case,
-            &Position::new(1, 9),
+            Position::new(1, 9),
             true,
             None,
             Some(&vec![Location {

--- a/test-suite/src/rename.rs
+++ b/test-suite/src/rename.rs
@@ -33,7 +33,7 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        lspresso_shot!(test_rename(test_case, &Position::default(), "", None, None));
+        lspresso_shot!(test_rename(test_case, Position::default(), "", None, None));
     }
 
     #[rstest]
@@ -49,7 +49,7 @@ mod test {
         send_capabiltiies(&rename_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_rename(test_case.clone(), &Position::default(), "", None, None);
+        let test_result = test_rename(test_case.clone(), Position::default(), "", None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{edits:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -69,7 +69,7 @@ mod test {
 
         lspresso_shot!(test_rename(
             test_case,
-            &Position::default(),
+            Position::default(),
             "",
             None,
             Some(&edits)
@@ -94,7 +94,7 @@ mod test {
 
         lspresso_shot!(test_rename(
             rename_test_case,
-            &Position::new(1, 9),
+            Position::new(1, 9),
             "bar",
             None,
             Some(&WorkspaceEdit {

--- a/test-suite/src/semantic_tokens_range.rs
+++ b/test-suite/src/semantic_tokens_range.rs
@@ -48,7 +48,7 @@ mod test {
 
         lspresso_shot!(test_semantic_tokens_range(
             test_case,
-            &Range::default(),
+            Range::default(),
             None,
             None
         ));
@@ -73,7 +73,7 @@ mod test {
         )
         .expect("Failed to send capabilities");
         let test_result =
-            test_semantic_tokens_range(test_case.clone(), &Range::default(), None, None);
+            test_semantic_tokens_range(test_case.clone(), Range::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
 
@@ -158,7 +158,7 @@ mod test {
 
         lspresso_shot!(test_semantic_tokens_range(
             test_case,
-            &Range::default(),
+            Range::default(),
             None,
             Some(&resp)
         ));
@@ -216,13 +216,13 @@ mod test {
             end: Position::new(0, 10),
         };
         for result in &possible_results {
-            if test_semantic_tokens_range(test_case.clone(), &range, None, Some(result)).is_ok() {
+            if test_semantic_tokens_range(test_case.clone(), range, None, Some(result)).is_ok() {
                 return;
             }
         }
         lspresso_shot!(test_semantic_tokens_range(
             test_case,
-            &range,
+            range,
             None,
             Some(&possible_results[1]),
         ));

--- a/test-suite/src/signature_help.rs
+++ b/test-suite/src/signature_help.rs
@@ -44,7 +44,7 @@ mod test {
 
         lspresso_shot!(test_signature_help(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None,
             None
@@ -66,7 +66,7 @@ mod test {
             .expect("Failed to send capabilities");
 
         let expected_err = TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
-        let test_result = test_signature_help(test_case, &Position::default(), None, None, None);
+        let test_result = test_signature_help(test_case, Position::default(), None, None, None);
         assert_eq!(Err(expected_err), test_result);
     }
 
@@ -86,7 +86,7 @@ mod test {
 
         lspresso_shot!(test_signature_help(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None,
             Some(&resp),
@@ -112,7 +112,7 @@ pub fn main() {
 
         lspresso_shot!(test_signature_help(
             test_case,
-            &Position::new(2, 8),
+            Position::new(2, 8),
             None,
             None,
             Some(&SignatureHelp {

--- a/test-suite/src/type_definition.rs
+++ b/test-suite/src/type_definition.rs
@@ -35,7 +35,7 @@ mod test {
 
         lspresso_shot!(test_type_definition(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None
         ));
@@ -55,7 +55,7 @@ mod test {
         send_capabiltiies(&type_definition_capabilities_simple(), &test_case_root)
             .expect("Failed to send capabilities");
 
-        let test_result = test_type_definition(test_case.clone(), &Position::default(), None, None);
+        let test_result = test_type_definition(test_case.clone(), Position::default(), None, None);
         let mut expected_err =
             TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
         if response_num == 3 {
@@ -87,7 +87,7 @@ mod test {
 
         lspresso_shot!(test_type_definition(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             Some(&resp)
         ));
@@ -115,7 +115,7 @@ pub fn main() {
 
         lspresso_shot!(test_type_definition(
             test_case,
-            &Position::new(5, 9),
+            Position::new(5, 9),
             None,
             Some(&GotoDefinitionResponse::Link(vec![LocationLink {
                 target_uri: Uri::from_str("src/main.rs").unwrap(),

--- a/test-suite/src/type_hierarchy.rs
+++ b/test-suite/src/type_hierarchy.rs
@@ -33,7 +33,7 @@ mod test {
 
         lspresso_shot!(test_prepare_type_hierarchy(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None,
             None
@@ -56,7 +56,7 @@ mod test {
             .expect("Failed to send capabilities");
 
         let test_result =
-            test_prepare_type_hierarchy(test_case.clone(), &Position::default(), None, None, None);
+            test_prepare_type_hierarchy(test_case.clone(), Position::default(), None, None, None);
         let expected_err = TestError::ExpectedNone(test_case.test_id, format!("{resp:#?}"));
         assert_eq!(Err(expected_err), test_result);
     }
@@ -78,7 +78,7 @@ mod test {
 
         lspresso_shot!(test_prepare_type_hierarchy(
             test_case,
-            &Position::default(),
+            Position::default(),
             None,
             None,
             Some(&resp)


### PR DESCRIPTION
- adds support for `textDocument/rangeFormatting`
- takes `Copy` parameters by value and a few non-`Copy` params by reference
- Make passing a `Range` parameter a little easier from `lspresso-shot/lib.rs`. This reduces some boilerplate and removes some unecessary panic docs from a few functions