### PR TITLE
feat(lib): `workspace/symbol`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ So far, we have:
 - [x] `textDocument/signatureHelp`
 - [x] `textDocument/typeDefinition`
 - [x] `workspace/diagnostic`
+- [x] `workspace/symbol`
 
 ## Gotchas/Known Issues
 

--- a/lspresso-shot/types/workspace_symbol.rs
+++ b/lspresso-shot/types/workspace_symbol.rs
@@ -1,0 +1,119 @@
+use lsp_types::{OneOf, SymbolInformation, WorkspaceSymbol, WorkspaceSymbolResponse};
+use thiserror::Error;
+
+use super::{
+    ApproximateEq, CleanResponse, Empty, TestResult, clean_uri, compare::write_fields_comparison,
+};
+
+impl Empty for WorkspaceSymbolResponse {}
+
+impl CleanResponse for WorkspaceSymbolResponse {
+    fn clean_response(mut self, test_case: &super::TestCase) -> TestResult<Self> {
+        match &mut self {
+            Self::Flat(symbols) => {
+                for symbol in symbols.iter_mut() {
+                    let uri = symbol.location.uri.clone();
+                    symbol.location.uri = clean_uri(&uri, test_case)?;
+                }
+            }
+            Self::Nested(symbols) => {
+                for symbol in symbols.iter_mut() {
+                    match &mut symbol.location {
+                        OneOf::Left(location) => {
+                            let uri = location.uri.clone();
+                            location.uri = clean_uri(&uri, test_case)?;
+                        }
+                        OneOf::Right(workspace_location) => {
+                            let uri = workspace_location.uri.clone();
+                            workspace_location.uri = clean_uri(&uri, test_case)?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub struct WorkspaceSymbolMismatchError {
+    pub test_id: String,
+    pub expected: WorkspaceSymbolResponse,
+    pub actual: WorkspaceSymbolResponse,
+}
+
+impl std::fmt::Display for WorkspaceSymbolMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Test {}: Incorrect Workspace Symbol response:",
+            self.test_id
+        )?;
+        write_fields_comparison(
+            f,
+            "WorkspaceSymbolResponse",
+            &self.expected,
+            &self.actual,
+            0,
+        )
+    }
+}
+
+impl ApproximateEq for WorkspaceSymbolResponse {
+    fn approx_eq(a: &Self, b: &Self) -> bool {
+        match (a, b) {
+            (Self::Nested(nested), Self::Flat(flat)) | (Self::Flat(flat), Self::Nested(nested)) => {
+                if flat.len() != nested.len() {
+                    return false;
+                }
+                !flat
+                    .iter()
+                    .zip(nested.iter())
+                    .any(|(sym_info, workspace_sym)| {
+                        !cmp_inner(sym_info, workspace_sym) // return true if *not* equal
+                    })
+            }
+            _ => a == b,
+        }
+    }
+}
+
+fn cmp_inner(sym_info: &SymbolInformation, workspace_sym: &WorkspaceSymbol) -> bool {
+    {
+        // The two are structurally identical in their JSON representations iff:
+        //   - `sym.deprecated` is `None`
+        //   - `workspace_sym.location` is the `Location` variant
+        //   - `workspace_sym.data` is `None`
+        #[allow(deprecated)]
+        if sym_info.deprecated.is_some() {
+            return false;
+        }
+        if workspace_sym.data.is_some() {
+            return false;
+        }
+        if let OneOf::Left(location) = &workspace_sym.location {
+            if sym_info.location != *location {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    // If we've confirmed the two are *structurally* identical, we now compare
+    // the remaining common fields
+    if sym_info.name != workspace_sym.name {
+        return false;
+    }
+    if sym_info.kind != workspace_sym.kind {
+        return false;
+    }
+    if sym_info.tags != workspace_sym.tags {
+        return false;
+    }
+    if sym_info.container_name != workspace_sym.container_name {
+        return false;
+    }
+
+    true
+}

--- a/test-server/src/handle.rs
+++ b/test-server/src/handle.rs
@@ -13,7 +13,7 @@ use lsp_types::{
     LinkedEditingRangeParams, MonikerParams, ReferenceParams, RenameParams, SelectionRangeParams,
     SemanticTokensDeltaParams, SemanticTokensParams, SemanticTokensRangeParams, ServerCapabilities,
     SignatureHelpParams, TextDocumentPositionParams, TypeHierarchyPrepareParams, Uri,
-    WorkspaceDiagnosticParams,
+    WorkspaceDiagnosticParams, WorkspaceSymbolParams,
     notification::{DidOpenTextDocument, Notification as _, PublishDiagnostics},
     request::{
         CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
@@ -26,7 +26,7 @@ use lsp_types::{
         PrepareRenameRequest, RangeFormatting, References, Rename, Request as _,
         ResolveCompletionItem, SelectionRangeRequest, SemanticTokensFullDeltaRequest,
         SemanticTokensFullRequest, SemanticTokensRangeRequest, SignatureHelpRequest,
-        TypeHierarchyPrepare, WorkspaceDiagnosticRequest,
+        TypeHierarchyPrepare, WorkspaceDiagnosticRequest, WorkspaceSymbolRequest,
     },
 };
 
@@ -48,6 +48,7 @@ use crate::{
         get_semantic_tokens_full_delta_response, get_semantic_tokens_full_response,
         get_semantic_tokens_range_response, get_signature_help_response,
         get_type_definition_response, get_workspace_diagnostics_response,
+        get_workspace_symbol_response,
     },
 };
 
@@ -577,6 +578,15 @@ pub fn handle_request(
                     let raw_uri = params.identifier.unwrap();
                     Uri::from_str(&raw_uri).unwrap()
                 }
+            )?;
+        }
+        WorkspaceSymbolRequest::METHOD => {
+            handle_request!(
+                WorkspaceSymbolRequest,
+                get_workspace_symbol_response,
+                req,
+                conn,
+                |params: WorkspaceSymbolParams| -> Uri { Uri::from_str(&params.query).unwrap() }
             )?;
         }
         method => error!("Unimplemented request method: {method:?}\n{req:?}"),

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -33,3 +33,4 @@ mod semantic_tokens_range;
 mod signature_help;
 mod type_definition;
 mod type_hierarchy;
+mod workspace_symbol;

--- a/test-suite/src/type_hierarchy.rs
+++ b/test-suite/src/type_hierarchy.rs
@@ -85,5 +85,5 @@ mod test {
         ));
     }
 
-    // NOTE: rust-analyzer doesn't support `textDocument/prepareTypeHierarchy` yet
+    // NOTE: rust-analyzer doesn't support `textDocument/prepareTypeHierarchy` requests
 }

--- a/test-suite/src/workspace_symbol.rs
+++ b/test-suite/src/workspace_symbol.rs
@@ -1,0 +1,130 @@
+#[cfg(test)]
+mod test {
+    use std::str::FromStr as _;
+
+    use crate::test_helpers::NON_RESPONSE_NUM;
+    use lspresso_shot::{
+        lspresso_shot, test_workspace_symbol,
+        types::{TestCase, TestError, TestFile},
+    };
+    use test_server::{get_dummy_server_path, send_capabiltiies, send_response_num};
+
+    use lsp_types::{OneOf, ServerCapabilities, Uri};
+    use rstest::rstest;
+
+    fn workspace_symbol_capabilities_simple() -> ServerCapabilities {
+        ServerCapabilities {
+            workspace_symbol_provider: Some(OneOf::Left(true)),
+            ..ServerCapabilities::default()
+        }
+    }
+
+    fn get_dummy_uri(test_case: &TestCase) -> String {
+        test_case
+            .get_source_file_path("main.dummy")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn test_server_simple_expect_none_got_none() {
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        let uri = test_case
+            .get_source_file_path("")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        send_response_num(NON_RESPONSE_NUM, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&workspace_symbol_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+
+        lspresso_shot!(test_workspace_symbol(test_case, &uri, None, None));
+    }
+
+    #[rstest]
+    fn test_server_simple_expect_none_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7)] response_num: u32,
+    ) {
+        // NOTE: The URI passed here matches the cleaned URI in the response
+        let resp = test_server::responses::get_workspace_symbol_response(
+            response_num,
+            &Uri::from_str("main.dummy").unwrap(),
+        )
+        .unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&workspace_symbol_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let uri = get_dummy_uri(&test_case);
+
+        let test_result = test_workspace_symbol(test_case.clone(), &uri, None, None);
+        let mut expected_err =
+            TestError::ExpectedNone(test_case.test_id.clone(), format!("{resp:#?}"));
+        match response_num {
+            // HACK: Because of the serialization issues with `WorkspaceSymbolResponse`, we have
+            // to work around
+            1 => {
+                assert_eq!(
+                    expected_err,
+                    TestError::ExpectedNone(
+                        test_case.test_id.clone(),
+                        "Nested(\n    [],\n)".to_string()
+                    ),
+                );
+                expected_err =
+                    TestError::ExpectedNone(test_case.test_id, "Flat(\n    [],\n)".to_string());
+            }
+            5 => {
+                assert_eq!(
+                    expected_err,
+                    TestError::ExpectedNone(
+                        test_case.test_id.clone(),
+                        "Nested(\n    [\n        WorkspaceSymbol {\n            name: \"name1\",\n            kind: File,\n            tags: Some(\n                [\n                    Deprecated,\n                ],\n            ),\n            container_name: None,\n            location: Left(\n                Location {\n                    uri: Uri(\n                        Uri {\n                            scheme: None,\n                            authority: None,\n                            path: \"main.dummy\",\n                            query: None,\n                            fragment: None,\n                        },\n                    ),\n                    range: Range {\n                        start: Position {\n                            line: 0,\n                            character: 0,\n                        },\n                        end: Position {\n                            line: 0,\n                            character: 0,\n                        },\n                    },\n                },\n            ),\n            data: None,\n        },\n    ],\n)".to_string(),
+                    ),
+                );
+                expected_err = TestError::ExpectedNone(
+                    test_case.test_id,
+                    "Flat(\n    [\n        SymbolInformation {\n            name: \"name1\",\n            kind: File,\n            tags: Some(\n                [\n                    Deprecated,\n                ],\n            ),\n            deprecated: None,\n            location: Location {\n                uri: Uri(\n                    Uri {\n                        scheme: None,\n                        authority: None,\n                        path: \"main.dummy\",\n                        query: None,\n                        fragment: None,\n                    },\n                ),\n                range: Range {\n                    start: Position {\n                        line: 0,\n                        character: 0,\n                    },\n                    end: Position {\n                        line: 0,\n                        character: 0,\n                    },\n                },\n            },\n            container_name: None,\n        },\n    ],\n)".to_string(),
+                );
+            }
+            _ => {}
+        }
+        assert_eq!(Err(expected_err), test_result);
+    }
+
+    #[rstest]
+    fn test_server_simple_expect_some_got_some(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7)] response_num: u32,
+    ) {
+        let uri = Uri::from_str(&test_server::get_dummy_source_path()).unwrap();
+        let resp =
+            test_server::responses::get_workspace_symbol_response(response_num, &uri).unwrap();
+        let source_file = TestFile::new(test_server::get_dummy_source_path(), "");
+        let test_case = TestCase::new(get_dummy_server_path(), source_file);
+
+        let test_case_root = test_case
+            .get_lspresso_dir()
+            .expect("Failed to get test case's root directory");
+        send_response_num(response_num, &test_case_root).expect("Failed to send response num");
+        send_capabiltiies(&workspace_symbol_capabilities_simple(), &test_case_root)
+            .expect("Failed to send capabilities");
+        let uri = get_dummy_uri(&test_case);
+
+        lspresso_shot!(test_workspace_symbol(test_case, &uri, None, Some(&resp)));
+    }
+
+    // TODO: rust-analyzer tests
+}


### PR DESCRIPTION
Followups:

- Implement `ApproximateEq` for other affected response types
- Generify `TestResult` to help cut down on redundant code