### PR TITLE
fix(lib): finish `ApproximateEq` implementations

### DIFF
--- a/lspresso-shot/init_dot_lua.rs
+++ b/lspresso-shot/init_dot_lua.rs
@@ -20,7 +20,6 @@ pub fn get_init_dot_lua(
         }
         _ => include_str!("lua_templates/request_action.lua"),
     });
-    let replacement_set = LuaDocumentReplacement::new(replacements);
     raw_init.push_str(include_str!("lua_templates/attach.lua"));
     // This is how we get neovim to actually invoke the action to be tested
     raw_init = match test_type {
@@ -28,6 +27,7 @@ pub fn get_init_dot_lua(
         TestType::PublishDiagnostics => raw_init.replace("LSP_ACTION", ""),
         _ => raw_init.replace("LSP_ACTION", &invoke_lsp_action(&test_case.start_type)),
     };
+    let replacement_set = LuaDocumentReplacement::new(replacements);
     let final_init = replacement_set.fill_document(raw_init);
 
     Ok(final_init)

--- a/lspresso-shot/types/definition.rs
+++ b/lspresso-shot/types/definition.rs
@@ -1,6 +1,6 @@
 use lsp_types::GotoDefinitionResponse;
 
-use super::{CleanResponse, TestCase, TestExecutionResult, clean_uri};
+use super::{ApproximateEq, CleanResponse, TestCase, TestExecutionResult, clean_uri};
 
 impl CleanResponse for GotoDefinitionResponse {
     fn clean_response(mut self, test_case: &TestCase) -> TestExecutionResult<Self> {
@@ -20,5 +20,23 @@ impl CleanResponse for GotoDefinitionResponse {
             }
         }
         Ok(self)
+    }
+}
+
+// NOTE: The following other requests' response types are simply aliased to this type:
+//  - `GotoDeclarationResponse`
+//  - `GotoTypeDefinitionResponse`
+//  - `GotoImplementationResponse`
+impl ApproximateEq for GotoDefinitionResponse {
+    fn approx_eq(a: &Self, b: &Self) -> bool {
+        match (a, b) {
+            (Self::Scalar(a), Self::Scalar(b)) => a == b,
+            (Self::Array(a), Self::Array(b)) => a == b,
+            (Self::Link(a), Self::Link(b)) => a == b,
+            (Self::Array(array), Self::Link(link)) | (Self::Link(link), Self::Array(array)) => {
+                link.is_empty() && array.is_empty()
+            }
+            _ => false,
+        }
     }
 }

--- a/lspresso-shot/types/document_symbol.rs
+++ b/lspresso-shot/types/document_symbol.rs
@@ -1,6 +1,6 @@
 use lsp_types::DocumentSymbolResponse;
 
-use super::{CleanResponse, TestCase, TestExecutionResult, clean_uri};
+use super::{ApproximateEq, CleanResponse, TestCase, TestExecutionResult, clean_uri};
 
 impl CleanResponse for DocumentSymbolResponse {
     fn clean_response(mut self, test_case: &TestCase) -> TestExecutionResult<Self> {
@@ -13,5 +13,17 @@ impl CleanResponse for DocumentSymbolResponse {
             Self::Nested(_) => {}
         }
         Ok(self)
+    }
+}
+
+impl ApproximateEq for DocumentSymbolResponse {
+    fn approx_eq(a: &Self, b: &Self) -> bool {
+        match (a, b) {
+            (Self::Flat(sym_info), Self::Nested(doc_syms))
+            | (Self::Nested(doc_syms), Self::Flat(sym_info)) => {
+                sym_info.is_empty() && doc_syms.is_empty()
+            }
+            _ => a == b,
+        }
     }
 }

--- a/lspresso-shot/types/semantic_tokens.rs
+++ b/lspresso-shot/types/semantic_tokens.rs
@@ -1,7 +1,51 @@
 use lsp_types::{SemanticTokensFullDeltaResult, SemanticTokensRangeResult, SemanticTokensResult};
 
-use super::CleanResponse;
+use super::{ApproximateEq, CleanResponse};
 
 impl CleanResponse for SemanticTokensResult {}
 impl CleanResponse for SemanticTokensFullDeltaResult {}
 impl CleanResponse for SemanticTokensRangeResult {}
+
+impl ApproximateEq for SemanticTokensResult {
+    fn approx_eq(a: &Self, b: &Self) -> bool {
+        match (a, b) {
+            (Self::Tokens(tokens), Self::Partial(partial))
+            | (Self::Partial(partial), Self::Tokens(tokens)) => {
+                tokens.result_id.is_none() && tokens.data.eq(&partial.data)
+            }
+            _ => a == b,
+        }
+    }
+}
+
+impl ApproximateEq for SemanticTokensFullDeltaResult {
+    fn approx_eq(a: &Self, b: &Self) -> bool {
+        match (a, b) {
+            (Self::Tokens(tokens), Self::TokensDelta(delta))
+            | (Self::TokensDelta(delta), Self::Tokens(tokens)) => {
+                tokens.result_id.is_none() && tokens.data.is_empty() && delta.edits.is_empty()
+            }
+            (Self::Tokens(tokens), Self::PartialTokensDelta { edits })
+            | (Self::PartialTokensDelta { edits }, Self::Tokens(tokens)) => {
+                tokens.result_id.is_none() && tokens.data.is_empty() && edits.is_empty()
+            }
+            (Self::TokensDelta(delta), Self::PartialTokensDelta { edits })
+            | (Self::PartialTokensDelta { edits }, Self::TokensDelta(delta)) => {
+                delta.result_id.is_none() && delta.edits.is_empty() && edits.is_empty()
+            }
+            _ => a == b,
+        }
+    }
+}
+
+impl ApproximateEq for SemanticTokensRangeResult {
+    fn approx_eq(a: &Self, b: &Self) -> bool {
+        match (a, b) {
+            (Self::Tokens(tokens), Self::Partial(partial))
+            | (Self::Partial(partial), Self::Tokens(tokens)) => {
+                tokens.result_id.is_none() && tokens.data.eq(&partial.data)
+            }
+            _ => a == b,
+        }
+    }
+}

--- a/lspresso-shot/types/workspace_symbol.rs
+++ b/lspresso-shot/types/workspace_symbol.rs
@@ -50,29 +50,27 @@ impl ApproximateEq for WorkspaceSymbolResponse {
 }
 
 fn cmp_inner(sym_info: &SymbolInformation, workspace_sym: &WorkspaceSymbol) -> bool {
-    {
-        // The two are structurally identical in their JSON representations iff:
-        //   - `sym.deprecated` is `None`
-        //   - `workspace_sym.location` is the `Location` variant
-        //   - `workspace_sym.data` is `None`
-        #[allow(deprecated)]
-        if sym_info.deprecated.is_some() {
+    // The two are structurally identical in their JSON representations iff:
+    //   - `sym_info.deprecated` is `None`
+    //   - `workspace_sym.location` is the `OneOf::Left(Location)` variant
+    //   - `workspace_sym.data` is `None`
+    #[allow(deprecated)]
+    if sym_info.deprecated.is_some() {
+        return false;
+    }
+    if workspace_sym.data.is_some() {
+        return false;
+    }
+    if let OneOf::Left(location) = &workspace_sym.location {
+        if sym_info.location != *location {
             return false;
         }
-        if workspace_sym.data.is_some() {
-            return false;
-        }
-        if let OneOf::Left(location) = &workspace_sym.location {
-            if sym_info.location != *location {
-                return false;
-            }
-        } else {
-            return false;
-        }
+    } else {
+        return false;
     }
 
-    // If we've confirmed the two are *structurally* identical, we now compare
-    // the remaining common fields
+    // If we've confirmed the two are *structurally* identical, compare the
+    // remaining common fields
     if sym_info.name != workspace_sym.name {
         return false;
     }


### PR DESCRIPTION
This pulls all of the hacky logic from the affected `test_*` functions to `ApproximateEq` trait implementations. This is necessary for request response types where multiple types can be deserialized from the same JSON.