### PR TITLE
fix(ci): workaround lack of tty in GH runners

### DIFF
--- a/.github/workflows/build_lint_test.yml
+++ b/.github/workflows/build_lint_test.yml
@@ -57,8 +57,7 @@ jobs:
     # HACK: We also need some means of propagating the test runner's exit
     # code. Using this hack for now, but there may be a better way
     - name: Run tests
-      run: |
-        script -q -c "cargo test -- --nocapture; echo \$? > exitcode" && exit $(cat exitcode)
+      run: cargo test
 
     - name: Install luals
       run: |

--- a/lspresso-shot/lib.rs
+++ b/lspresso-shot/lib.rs
@@ -212,10 +212,12 @@ fn run_test(test_case: &TestCase, source_path: &Path) -> TestExecutionResult<()>
         .arg(init_dot_lua_path)
         .arg("--noplugin")
         .arg(source_path)
-        .arg("--headless")
+        // NOTE: Running with `--headless` would be better, but this causes *all* tests
+        // to fail on GH's runners, likely due to the lack of appearance of a tty.
+        // .arg("--headless")
         .arg("-n") // disable swap files
-        .stdout(Stdio::null()) // Commenting these out can be helpful for local
-        .stderr(Stdio::null()) // debugging, can print some logs from the server
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| TestExecutionError::Neovim(test_case.test_id.clone(), e.to_string()))?;
 


### PR DESCRIPTION
A much cleaner solution to https://github.com/WillLillis/lspresso-shot/pull/1

While it would be nice to invoke neovim with `--headless`, having tests pass in CI without anything wrapping `cargo test` is much nicer. 